### PR TITLE
add travis yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,31 @@
+language: cpp
+
+env:
+
+compiler:
+  - gcc
+
+before_script:
+
+script: "cd src && make -f makefile.unix test"
+
+branches:
+  only:
+    - master
+    - feature/travis_ci
+
+install:
+  - sudo apt-get install build-essential pkg-config
+  - sudo apt-get install libtool autotools-dev autoconf
+  - sudo apt-get install libssl-dev
+  - sudo apt-get install libdb5.1-dev
+  - sudo apt-get install libdb5.1++-dev
+  - sudo apt-get install libboost-all-dev
+  - sudo apt-get install libminiupnpc-dev
+notifications:
+  recipients:
+    - project_mail_address@gmail.com
+  email:
+    on_success: change
+    on_failure: always
+


### PR DESCRIPTION
hi, I am one of the fan of this project :D
adding .travis.yml for _Automated Testing_.
unfortunately, test does not seem to pass.
if is it ok, would you please disable these tests?

```
test/alert_tests.cpp(126): error in "AlertApplies": check alert.CheckSignature() failed
test/alert_tests.cpp(126): error in "AlertApplies": check alert.CheckSignature() failed
test/alert_tests.cpp(126): error in "AlertApplies": check alert.CheckSignature() failed
test/alert_tests.cpp(126): error in "AlertApplies": check alert.CheckSignature() failed
test/alert_tests.cpp(126): error in "AlertApplies": check alert.CheckSignature() failed
test/alert_tests.cpp(126): error in "AlertApplies": check alert.CheckSignature() failed
test/alert_tests.cpp(126): error in "AlertApplies": check alert.CheckSignature() failed
test/alert_tests.cpp(126): error in "AlertApplies": check alert.CheckSignature() failed
test/alert_tests.cpp(129): error in "AlertApplies": check alerts[0].AppliesTo(1, "") failed
test/alert_tests.cpp(130): error in "AlertApplies": check alerts[0].AppliesTo(70001, "") failed
test/alert_tests.cpp(131): error in "AlertApplies": check alerts[0].AppliesTo(1, "/Satoshi:11.11.11/") failed
test/alert_tests.cpp(133): error in "AlertApplies": check alerts[1].AppliesTo(1, "/Satoshi:0.1.0/") failed
test/alert_tests.cpp(134): error in "AlertApplies": check alerts[1].AppliesTo(70001, "/Satoshi:0.1.0/") failed
test/alert_tests.cpp(136): error in "AlertApplies": check alerts[2].AppliesTo(1, "/Satoshi:0.1.0/") failed
test/alert_tests.cpp(137): error in "AlertApplies": check alerts[2].AppliesTo(1, "/Satoshi:0.2.0/") failed
test/alert_tests.cpp(173): error in "AlertNotify": check r.size() == 1u failed [0 != 1]
unknown location(0): fatal error in "AlertNotify": memory access violation at address: 0x00000000: no mapping at fault address
test/alert_tests.cpp(174): last checkpoint
```
