### PR TITLE
Fix_japanese_translation&#x1f1ef;&#x1f1f5;

### DIFF
--- a/src/qt/locale/bitcoin_ja.ts
+++ b/src/qt/locale/bitcoin_ja.ts
@@ -1046,7 +1046,7 @@
     </message>
     <message>
         <source>Expert</source>
-        <translation>エクスポート</translation>
+        <translation>上級者向け</translation>
     </message>
     <message>
         <source>Enable coin &amp;control features</source>
@@ -1269,7 +1269,7 @@
     </message>
     <message>
         <source>Mined balance in watch-only addresses that has not yet matured</source>
-        <translation>ウォッチオンリーアドレスの採掘された残高のうち、成熟していないもの</translation>
+        <translation>監視限定アドレスの採掘された残高のうち、成熟していないもの</translation>
     </message>
     <message>
         <source>Current total balance in watch-only addresses</source>
@@ -1292,7 +1292,7 @@
     </message>
     <message>
         <source>Payment request fetch URL is invalid: %1</source>
-        <translation>支払い要求の取得先URLが無効です: %1</translation>
+        <translation>支払いリクエストの取得先URLが無効です: %1</translation>
     </message>
     <message>
         <source>Invalid payment address %1</source>
@@ -1312,7 +1312,7 @@
     </message>
     <message>
         <source>Payment request rejected</source>
-        <translation>支払い要求は拒否されました</translation>
+        <translation>支払いリクエストは拒否されました</translation>
     </message>
     <message>
         <source>Payment request network doesn't match client network.</source>
@@ -1336,7 +1336,7 @@
     </message>
     <message>
         <source>Requested payment amount of %1 is too small (considered dust).</source>
-        <translation>要求された支払額 %1 は少なすぎます (ダストとみなされてしまいます)。</translation>
+        <translation>支払リクエスト %1 は少なすぎます (ダストとみなされてしまいます)。</translation>
     </message>
     <message>
         <source>Refund from %1</source>
@@ -1348,7 +1348,7 @@
     </message>
     <message>
         <source>Error communicating with %1: %2</source>
-        <translation>%1: %2とコミュニケーション・エラーです</translation>
+        <translation>%1: %2と通信エラーです</translation>
     </message>
     <message>
         <source>Payment request cannot be parsed!</source>
@@ -1356,11 +1356,11 @@
     </message>
     <message>
         <source>Bad response from server %1</source>
-        <translation>サーバーの返事は無効 %1</translation>
+        <translation>サーバーの応答が無効 %1</translation>
     </message>
     <message>
         <source>Network request error</source>
-        <translation>ネットワーク・リクエストのエラーです</translation>
+        <translation>ネットワーク要求エラーです</translation>
     </message>
     <message>
         <source>Payment acknowledged</source>
@@ -1402,11 +1402,11 @@
     </message>
     <message>
         <source>%1 h</source>
-        <translation>%1 h</translation>
+        <translation>%1時間</translation>
     </message>
     <message>
         <source>%1 m</source>
-        <translation>%1 m</translation>
+        <translation>%1分</translation>
     </message>
     <message>
         <source>%1 s</source>
@@ -1655,7 +1655,7 @@
     </message>
     <message>
         <source>Time Offset</source>
-        <translation>時間オフセット</translation>
+        <translation>タイムオフセット</translation>
     </message>
     <message>
         <source>Last block time</source>
@@ -2119,7 +2119,7 @@
     </message>
     <message>
         <source>Copy amount</source>
-        <translation>総額のコピー</translation>
+        <translation>総額のコピーする</translation>
     </message>
     <message>
         <source>Copy fee</source>
@@ -2139,7 +2139,7 @@
     </message>
     <message>
         <source>Copy change</source>
-        <translation>釣り銭をコピー</translation>
+        <translation>釣り銭をコピーする</translation>
     </message>
     <message>
         <source>%1 to %2</source>

--- a/src/qt/locale/bitcoin_ja.ts
+++ b/src/qt/locale/bitcoin_ja.ts
@@ -645,7 +645,7 @@
     </message>
     <message>
         <source>Copy amount</source>
-        <translation>総額のコピー</translation>
+        <translation>総額をコピー</translation>
     </message>
     <message>
         <source>Copy transaction ID</source>
@@ -681,7 +681,7 @@
     </message>
     <message>
         <source>Copy change</source>
-        <translation>釣り銭をコピー</translation>
+        <translation>釣り銭をコピーする</translation>
     </message>
     <message>
         <source>(%1 locked)</source>
@@ -1878,7 +1878,7 @@
     </message>
     <message>
         <source>Copy amount</source>
-        <translation>総額のコピー</translation>
+        <translation>総額をコピーする</translation>
     </message>
 </context>
 <context>
@@ -2119,7 +2119,7 @@
     </message>
     <message>
         <source>Copy amount</source>
-        <translation>総額のコピーする</translation>
+        <translation>総額をコピーする</translation>
     </message>
     <message>
         <source>Copy fee</source>
@@ -2861,7 +2861,7 @@
     </message>
     <message>
         <source>Copy amount</source>
-        <translation>総額のコピー</translation>
+        <translation>総額をコピーする</translation>
     </message>
     <message>
         <source>Copy transaction ID</source>

--- a/src/qt/locale/bitcoin_ja_JP.ts
+++ b/src/qt/locale/bitcoin_ja_JP.ts
@@ -3,11 +3,11 @@
     <name>AddressBookPage</name>
     <message>
         <source>Right-click to edit address or label</source>
-        <translation>編集するためにアドレスもしくはラベルを右クリックします</translation>
+        <translation>右クリックでアドレスまたはラベルを編集します</translation>
     </message>
     <message>
         <source>Create a new address</source>
-        <translation>新しいアドレスを作成します</translation>
+        <translation>新規アドレスの作成</translation>
     </message>
     <message>
         <source>&amp;New</source>
@@ -15,87 +15,87 @@
     </message>
     <message>
         <source>Copy the currently selected address to the system clipboard</source>
-        <translation>クリップボードに現在選択されているアドレスをコピーします</translation>
+        <translation>現在選択されているアドレスをシステムのクリップボードにコピーする</translation>
     </message>
     <message>
         <source>&amp;Copy</source>
-        <translation>&amp;コピー</translation>
+        <translation>コピー(&amp;C)</translation>
     </message>
     <message>
         <source>C&amp;lose</source>
-        <translation>C&amp;失敗</translation>
+        <translation>閉じる(&amp;C)</translation>
     </message>
     <message>
         <source>Delete the currently selected address from the list</source>
-        <translation>リストから現在選択中のアドレスを削除します</translation>
+        <translation>選択されたアドレスを一覧から削除する</translation>
     </message>
     <message>
         <source>Export the data in the current tab to a file</source>
-        <translation>ファイルの現在のタブを出力します</translation>
+        <translation>ファイルに現在のタブのデータをエクスポート</translation>
     </message>
     <message>
         <source>&amp;Export</source>
-        <translation>&amp;出力</translation>
+        <translation>エクスポート (&amp;E)</translation>
     </message>
     <message>
         <source>&amp;Delete</source>
-        <translation>&amp;削除</translation>
+        <translation>削除(&amp;D)</translation>
     </message>
     <message>
         <source>Choose the address to send coins to</source>
-        <translation>送付するコインのアドレスを選択</translation>
+        <translation>先のアドレスを選択</translation>
     </message>
     <message>
         <source>Choose the address to receive coins with</source>
-        <translation>受け取るコインのアドレスを選択</translation>
+        <translation>支払いを受け取るアドレスを指定する</translation>
     </message>
     <message>
         <source>C&amp;hoose</source>
-        <translation>C&amp;選択</translation>
+        <translation>選択 (&amp;C)</translation>
     </message>
     <message>
         <source>Sending addresses</source>
-        <translation>アドレス送信</translation>
+        <translation>送金用</translation>
     </message>
     <message>
         <source>Receiving addresses</source>
-        <translation>アドレス受信</translation>
+        <translation>受け取りアドレス</translation>
     </message>
     <message>
         <source>These are your Monacoin addresses for sending payments. Always check the amount and the receiving address before sending coins.</source>
-        <translation>支払送信するためのモナーコインアドレスです。コインを送付する前に、いつも残高と受信アドレスの確認をしてください。</translation>
+        <translation>これらは支払いを送信するためのあなたの Monacoin アドレスです。コインを送信する前に、常に額と受信アドレスを確認してください。</translation>
     </message>
     <message>
         <source>These are your Monacoin addresses for receiving payments. It is recommended to use a new receiving address for each transaction.</source>
-        <translation>支払の受信をするためのモナーコインアドレスです。それぞれの処理に新規に受信アドレスを使用することを推奨します。</translation>
+        <translation>これらは支払いを受け取るためのモナーコインアドレスです。トランザクションごとに新しい受け取り用アドレスを作成することが推奨されます。</translation>
     </message>
     <message>
         <source>&amp;Copy Address</source>
-        <translation>&amp;アドレスのコピー</translation>
+        <translation>アドレスをコピー (&amp;C)</translation>
     </message>
     <message>
         <source>Copy &amp;Label</source>
-        <translation>コピー&amp;ラベル</translation>
+        <translation>ラベルをコピー (&amp;L)</translation>
     </message>
     <message>
         <source>&amp;Edit</source>
-        <translation>&amp;編集</translation>
+        <translation>編集 (&amp;E)</translation>
     </message>
     <message>
         <source>Export Address List</source>
-        <translation>アドレス一覧の出力</translation>
+        <translation>アドレス帳をエクスポート</translation>
     </message>
     <message>
         <source>Comma separated file (*.csv)</source>
-        <translation>カンマ区切りのファイル(*.csv)</translation>
+        <translation>テキスト CSV (*.csv)</translation>
     </message>
     <message>
         <source>Exporting Failed</source>
-        <translation>出力の失敗</translation>
+        <translation>エクスポートに失敗しました</translation>
     </message>
     <message>
         <source>There was an error trying to save the address list to %1. Please try again.</source>
-        <translation>%1のため、アドレス一覧の保存中のエラーが発生しました。もう一度、実行してください。</translation>
+        <translation>トランザクション履歴を %1 へ保存する際にエラーが発生しました。再試行してください。</translation>
     </message>
 </context>
 <context>
@@ -110,50 +110,50 @@
     </message>
     <message>
         <source>(no label)</source>
-        <translation>(ラベルなし)</translation>
+        <translation>(ラベル無し)</translation>
     </message>
 </context>
 <context>
     <name>AskPassphraseDialog</name>
     <message>
         <source>Passphrase Dialog</source>
-        <translation>パスフレーズダイヤログ</translation>
+        <translation>パスフレーズ ダイアログ</translation>
     </message>
     <message>
         <source>Enter passphrase</source>
-        <translation>パスフレーズの入力</translation>
+        <translation>パスフレーズを入力</translation>
     </message>
     <message>
         <source>New passphrase</source>
-        <translation>新規のパスフレーズ</translation>
+        <translation>新しいパスフレーズ</translation>
     </message>
     <message>
         <source>Repeat new passphrase</source>
-        <translation>新規パスフレーズの繰り返し</translation>
+        <translation>新しいパスフレーズをもう一度</translation>
     </message>
     <message>
         <source>Enter the new passphrase to the wallet.&lt;br/&gt;Please use a passphrase of &lt;b&gt;ten or more random characters&lt;/b&gt;, or &lt;b&gt;eight or more words&lt;/b&gt;.</source>
-        <translation>財布に新規パスフレーズの入力をします。&lt;br/&gt;パスフレーズを使ってください &lt;b&gt;10以上のランダム文字列&lt;/b&gt;もしくは &lt;b&gt;8以上の単語&lt;/b&gt;.</translation>
+        <translation>ウォレットの新しいパスフレーズを入力してください。&lt;br/&gt;&lt;b&gt;10文字以上のランダムな文字&lt;/b&gt;で構成されたものか、&lt;b&gt;8単語以上の単語&lt;/b&gt;で構成されたパスフレーズを使用してください。</translation>
     </message>
     <message>
         <source>Encrypt wallet</source>
-        <translation>財布を暗号化します</translation>
+        <translation>ウォレットを暗号化する</translation>
     </message>
     <message>
         <source>This operation needs your wallet passphrase to unlock the wallet.</source>
-        <translation>この操作は、財布のロックを解除するために財布のパスフレーズが必要です。</translation>
+        <translation>この操作はウォレットをアンロックするためにパスフレーズが必要です。</translation>
     </message>
     <message>
         <source>Unlock wallet</source>
-        <translation>財布のロック解除</translation>
+        <translation>ウォレットをアンロックする</translation>
     </message>
     <message>
         <source>This operation needs your wallet passphrase to decrypt the wallet.</source>
-        <translation>この操作は、財布を複合化するために財布のパスフレーズが必要です。</translation>
+        <translation>この操作はウォレットの暗号化解除のためにパスフレーズが必要です。</translation>
     </message>
     <message>
         <source>Decrypt wallet</source>
-        <translation>財布の復号化</translation>
+        <translation>ウォレットの暗号化を解除する</translation>
     </message>
     <message>
         <source>Change passphrase</source>
@@ -161,63 +161,63 @@
     </message>
     <message>
         <source>Enter the old passphrase and new passphrase to the wallet.</source>
-        <translation>財布に古いパスフレーズと新規パスフレーズを入力します。</translation>
+        <translation>ウォレットの古いパスフレーズおよび新しいパスフレーズを入力してください。</translation>
     </message>
     <message>
         <source>Confirm wallet encryption</source>
-        <translation>財布の暗号化を確認します</translation>
+        <translation>ウォレットの暗号化を確認する</translation>
     </message>
     <message>
         <source>Warning: If you encrypt your wallet and lose your passphrase, you will &lt;b&gt;LOSE ALL OF YOUR MONACOINS&lt;/b&gt;!</source>
-        <translation>注意: 財布の暗号化やパスフレーズを忘れた場合、 &lt;b&gt;あなたのモナーコインはすべて失われます。&lt;/b&gt;!</translation>
+        <translation>警告: もしもあなたのウォレットを暗号化してパスフレーズを失ってしまったなら、&lt;b&gt;あなたの Monacoin はすべて失われます&lt;/b&gt;!</translation>
     </message>
     <message>
         <source>Are you sure you wish to encrypt your wallet?</source>
-        <translation>財布を暗号化してもよろしいですか？</translation>
+        <translation>本当にウォレットを暗号化しますか?</translation>
     </message>
     <message>
         <source>Wallet encrypted</source>
-        <translation>暗号化された財布</translation>
+        <translation>ウォレットは暗号化されました</translation>
     </message>
     <message>
         <source>%1 will close now to finish the encryption process. Remember that encrypting your wallet cannot fully protect your monacoins from being stolen by malware infecting your computer.</source>
-        <translation>暗号化処理を終了させるために、すぐに%1を閉じるでしょう。あなたのコンピュータに感染したマルウェアによって、盗まれたモナーコインは暗号化をしていても完全に守ることができないことを覚えておいてください。</translation>
+        <translation>暗号化処理を完了させるため %1 をいますぐ終了します。ウォレットの暗号化では、コンピュータに感染したマルウェアなどによるモナーコインの盗難から完全に守ることはできないことにご注意ください。</translation>
     </message>
     <message>
         <source>IMPORTANT: Any previous backups you have made of your wallet file should be replaced with the newly generated, encrypted wallet file. For security reasons, previous backups of the unencrypted wallet file will become useless as soon as you start using the new, encrypted wallet.</source>
-        <translation>重要: 以前の財布ファイルのバックアップは、新しく作成された暗号化された財布ファイルに置き換えられるべきです。セキュリティの観点から、暗号化されていない以前の財布ファイルは、新しく暗号化された財布が利用開始になり次第、間もなく使用できなくなります。</translation>
+        <translation>重要: 過去のウォレット ファイルのバックアップは、暗号化された新しいウォレット ファイルに取り替える必要があります。セキュリティ上の理由により、暗号化された新しいウォレットを使い始めると、暗号化されていないウォレット ファイルのバックアップはすぐに使えなくなります。</translation>
     </message>
     <message>
         <source>Wallet encryption failed</source>
-        <translation>財布の暗号化に失敗しました。</translation>
+        <translation>ウォレットの暗号化に失敗しました</translation>
     </message>
     <message>
         <source>Wallet encryption failed due to an internal error. Your wallet was not encrypted.</source>
-        <translation>内部エラーにより財布の暗号化に失敗しました。財布は暗号化されていません。</translation>
+        <translation>内部エラーによりウォレットの暗号化が失敗しました。ウォレットは暗号化されませんでした。</translation>
     </message>
     <message>
         <source>The supplied passphrases do not match.</source>
-        <translation>提供されたパスフレーズは一致しません。</translation>
+        <translation>パスフレーズが同じではありません。</translation>
     </message>
     <message>
         <source>Wallet unlock failed</source>
-        <translation>財布のロック解除に失敗しました。</translation>
+        <translation>ウォレットのアンロックに失敗しました</translation>
     </message>
     <message>
         <source>The passphrase entered for the wallet decryption was incorrect.</source>
-        <translation>財布の復号化のために入力されたパスフレーズが間違っています。</translation>
+        <translation>ウォレットの暗号化解除のパスフレーズが正しくありません。</translation>
     </message>
     <message>
         <source>Wallet decryption failed</source>
-        <translation>財布の復号化に失敗しました。</translation>
+        <translation>ウォレットの暗号化解除に失敗しました</translation>
     </message>
     <message>
         <source>Wallet passphrase was successfully changed.</source>
-        <translation>財布パスフレーズの変更に成功しました。</translation>
+        <translation>ウォレットのパスフレーズの変更が成功しました。</translation>
     </message>
     <message>
         <source>Warning: The Caps Lock key is on!</source>
-        <translation>注意: CapsLockキーが有効になっています!</translation>
+        <translation>警告: Caps Lock キーがオンになっています!</translation>
     </message>
 </context>
 <context>
@@ -228,22 +228,22 @@
     </message>
     <message>
         <source>Banned Until</source>
-        <translation>まで禁止</translation>
+        <translation>以下の時間までbanする:</translation>
     </message>
 </context>
 <context>
     <name>BitcoinGUI</name>
     <message>
         <source>Sign &amp;message...</source>
-        <translation>サイン &amp;メッセージ...</translation>
+        <translation>メッセージの署名... (&amp;m)</translation>
     </message>
     <message>
         <source>Synchronizing with network...</source>
-        <translation>ネットワークで同期中...</translation>
+        <translation>ネットワークに同期中……</translation>
     </message>
     <message>
         <source>&amp;Overview</source>
-        <translation>&amp;概要</translation>
+        <translation>概要(&amp;O)</translation>
     </message>
     <message>
         <source>Node</source>
@@ -251,19 +251,19 @@
     </message>
     <message>
         <source>Show general overview of wallet</source>
-        <translation>財布の一般概要を表示</translation>
+        <translation>ウォレットの概要を見る</translation>
     </message>
     <message>
         <source>&amp;Transactions</source>
-        <translation>&amp;処理</translation>
+        <translation>取引(&amp;T)</translation>
     </message>
     <message>
         <source>Browse transaction history</source>
-        <translation>処理の履歴を見る</translation>
+        <translation>取引履歴を閲覧</translation>
     </message>
     <message>
         <source>E&amp;xit</source>
-        <translation>退出</translation>
+        <translation>終了(&amp;E)</translation>
     </message>
     <message>
         <source>Quit application</source>
@@ -271,187 +271,187 @@
     </message>
     <message>
         <source>&amp;About %1</source>
-        <translation>&amp;%1について</translation>
+        <translation>%1 について (&amp;A)</translation>
     </message>
     <message>
         <source>Show information about %1</source>
-        <translation>%1についての情報を見る</translation>
+        <translation>%1 の情報を表示</translation>
     </message>
     <message>
         <source>About &amp;Qt</source>
-        <translation>&amp;Qtについて</translation>
+        <translation>Qt について(&amp;Q)</translation>
     </message>
     <message>
         <source>Show information about Qt</source>
-        <translation>Qtについての情報を見る</translation>
+        <translation>Qt の情報を表示</translation>
     </message>
     <message>
         <source>&amp;Options...</source>
-        <translation>&amp;オプション...</translation>
+        <translation>オプション... (&amp;O)</translation>
     </message>
     <message>
         <source>Modify configuration options for %1</source>
-        <translation>%1のオプション設定を変更する</translation>
+        <translation>%1 の設定を変更する</translation>
     </message>
     <message>
         <source>&amp;Encrypt Wallet...</source>
-        <translation>&amp;財布の暗号化...</translation>
+        <translation>ウォレットの暗号化... (&amp;E)</translation>
     </message>
     <message>
         <source>&amp;Backup Wallet...</source>
-        <translation>&amp;財布のバックアップ...</translation>
+        <translation>ウォレットのバックアップ... (&amp;B)</translation>
     </message>
     <message>
         <source>&amp;Change Passphrase...</source>
-        <translation>&amp;パスフレーズの変更...</translation>
+        <translation>パスフレーズの変更... (&amp;C)</translation>
     </message>
     <message>
         <source>&amp;Sending addresses...</source>
-        <translation>&amp;アドレスの送信...</translation>
+        <translation>送金先アドレス一覧 (&amp;S)...</translation>
     </message>
     <message>
         <source>&amp;Receiving addresses...</source>
-        <translation>&amp;アドレスの受信...</translation>
+        <translation>受け取り用アドレス一覧 (&amp;R)...</translation>
     </message>
     <message>
         <source>Open &amp;URI...</source>
-        <translation>オープン&amp;URI...</translation>
+        <translation>URI を開く (&amp;U)...</translation>
     </message>
     <message>
         <source>Click to disable network activity.</source>
-        <translation>ネットワーク処理を無効にするためにクリックする</translation>
+        <translation>クリックするとネットワーク活動を無効化します。</translation>
     </message>
     <message>
         <source>Network activity disabled.</source>
-        <translation>無効化されたネットワーク</translation>
+        <translation>ネットワーク活動は無効化されました。</translation>
     </message>
     <message>
         <source>Click to enable network activity again.</source>
-        <translation>再度、ネットワーク処理を有効化するために、クリック</translation>
+        <translation>クリックするとネットワーク活動を再び有効化します。</translation>
     </message>
     <message>
         <source>Syncing Headers (%1%)...</source>
-        <translation>ヘッダーを同期中 (%1%)...</translation>
+        <translation>未知。ヘッダを同期しています (%1%)...</translation>
     </message>
     <message>
         <source>Reindexing blocks on disk...</source>
-        <translation>ディスクのブロックの再インデックス中...</translation>
+        <translation>ディスク上のブロックのインデックスを再作成中...</translation>
     </message>
     <message>
         <source>Send coins to a Monacoin address</source>
-        <translation>モナーコインアドレスにコインを送信</translation>
+        <translation>Monacoin アドレスにコインを送る</translation>
     </message>
     <message>
         <source>Backup wallet to another location</source>
-        <translation>他の場所に財布をバックアップ</translation>
+        <translation>ウォレットを他の場所にバックアップ</translation>
     </message>
     <message>
         <source>Change the passphrase used for wallet encryption</source>
-        <translation>財布の暗号化に使用するパスフレーズを変更</translation>
+        <translation>ウォレット暗号化用パスフレーズの変更</translation>
     </message>
     <message>
         <source>&amp;Debug window</source>
-        <translation>&amp;デバッグ用ウィンドウ</translation>
+        <translation>デバッグ ウインドウ (&amp;D)</translation>
     </message>
     <message>
         <source>Open debugging and diagnostic console</source>
-        <translation>デバッグと診断のコンソールを開く</translation>
+        <translation>デバッグと診断コンソールを開く</translation>
     </message>
     <message>
         <source>&amp;Verify message...</source>
-        <translation>&amp;メッセージの確認...</translation>
+        <translation>メッセージの検証... (&amp;V)</translation>
     </message>
     <message>
         <source>Monacoin</source>
-        <translation>モナーコイン</translation>
+        <translation>Monacoin</translation>
     </message>
     <message>
         <source>Wallet</source>
-        <translation>財布</translation>
+        <translation>ウォレット</translation>
     </message>
     <message>
         <source>&amp;Send</source>
-        <translation>&amp;送信</translation>
+        <translation>送金 (&amp;S)</translation>
     </message>
     <message>
         <source>&amp;Receive</source>
-        <translation>&amp;受信</translation>
+        <translation>入金 (&amp;R)</translation>
     </message>
     <message>
         <source>&amp;Show / Hide</source>
-        <translation>&amp;表示/ 非表示</translation>
+        <translation>見る/隠す (&amp;S)</translation>
     </message>
     <message>
         <source>Show or hide the main Window</source>
-        <translation>メインウィンドウの表示もしくは非表示</translation>
+        <translation>メイン ウインドウを表示または非表示</translation>
     </message>
     <message>
         <source>Encrypt the private keys that belong to your wallet</source>
-        <translation>財布に属するプライベートキーの暗号化</translation>
+        <translation>あなたのウォレットの秘密鍵を暗号化します</translation>
     </message>
     <message>
         <source>Sign messages with your Monacoin addresses to prove you own them</source>
-        <translation>所有者であることを証明するためにモナーコインアドレスのメッセージにサイン</translation>
+        <translation>あなたが所有していることを証明するために、あなたの Monacoin アドレスでメッセージに署名してください</translation>
     </message>
     <message>
         <source>Verify messages to ensure they were signed with specified Monacoin addresses</source>
-        <translation>署名された特定のモナーコインアドレスを確認するために、メッセージを確認</translation>
+        <translation>指定された Monacoin アドレスで署名されたことを確認するためにメッセージを検証します</translation>
     </message>
     <message>
         <source>&amp;File</source>
-        <translation>&amp;ファイル</translation>
+        <translation>ファイル(&amp;F)</translation>
     </message>
     <message>
         <source>&amp;Settings</source>
-        <translation>&amp;設定</translation>
+        <translation>設定(&amp;S)</translation>
     </message>
     <message>
         <source>&amp;Help</source>
-        <translation>&amp;ヘルプ</translation>
+        <translation>ヘルプ(&amp;H)</translation>
     </message>
     <message>
         <source>Tabs toolbar</source>
-        <translation>ツールバータブ</translation>
+        <translation>タブツールバー</translation>
     </message>
     <message>
         <source>Request payments (generates QR codes and monacoin: URIs)</source>
-        <translation>支払の要求 (QRコードとモナーコインのURIを作成)</translation>
+        <translation>支払いを要求する (QRコードとmonacoin:ではじまるURIを生成する)</translation>
     </message>
     <message>
         <source>Show the list of used sending addresses and labels</source>
-        <translation>送信に使用したアドレスとラベルの一覧を表示</translation>
+        <translation>使用済みの送金用アドレスとラベルの一覧を表示する</translation>
     </message>
     <message>
         <source>Show the list of used receiving addresses and labels</source>
-        <translation>受信に使用したアドレスとラベルの一覧を表示</translation>
+        <translation>支払いを受け取るアドレスとラベルのリストを表示する</translation>
     </message>
     <message>
         <source>Open a monacoin: URI or payment request</source>
-        <translation>モナーコインのURIまたは支払要求を開く</translation>
+        <translation>monacoin: URIまたは支払いリクエストを開く</translation>
     </message>
     <message>
         <source>&amp;Command-line options</source>
-        <translation>&amp;コマンドラインのオプション</translation>
+        <translation>コマンドラインオプション (&amp;C)</translation>
     </message>
     <message>
         <source>Indexing blocks on disk...</source>
-        <translation>ディスクのブロックのインデックス化中...</translation>
+        <translation>ディスク上のブロックのインデックスを作成しています...</translation>
     </message>
     <message>
         <source>Processing blocks on disk...</source>
-        <translation>ディスクのブロックの処理中...</translation>
+        <translation>ディスク上のブロックを処理しています...</translation>
     </message>
     <message>
         <source>%1 behind</source>
-        <translation>%1残り</translation>
+        <translation>%1 遅延</translation>
     </message>
     <message>
         <source>Last received block was generated %1 ago.</source>
-        <translation>最後の受信ブロックは%1前に生成されました。</translation>
+        <translation>最後に受信されたブロックは %1 前に生成されました。</translation>
     </message>
     <message>
         <source>Transactions after this will not yet be visible.</source>
-        <translation>トランザクション後も、これらは見えることはありません。</translation>
+        <translation>この後の取引はまだ表示されません。</translation>
     </message>
     <message>
         <source>Error</source>
@@ -467,23 +467,23 @@
     </message>
     <message>
         <source>Up to date</source>
-        <translation>更新日</translation>
+        <translation>バージョンは最新です</translation>
     </message>
     <message>
         <source>Show the %1 help message to get a list with possible Monacoin command-line options</source>
-        <translation>モナーコインのコマンドラインオプションとして可能なリストの取得の%1ヘルプメッセージを表示</translation>
+        <translation>有効な Monacoin のコマンドライン オプションを見るために %1 のヘルプメッセージを表示します。</translation>
     </message>
     <message>
         <source>%1 client</source>
-        <translation>クライアント%1</translation>
+        <translation>%1 クライアント</translation>
     </message>
     <message>
         <source>Connecting to peers...</source>
-        <translation>ピアに接続中...</translation>
+        <translation>ピアに接続しています...</translation>
     </message>
     <message>
         <source>Catching up...</source>
-        <translation>追いつき中...</translation>
+        <translation>追跡中...</translation>
     </message>
     <message>
         <source>Date: %1
@@ -494,7 +494,7 @@
     <message>
         <source>Amount: %1
 </source>
-        <translation>残高: %1
+        <translation>総額: %1
 </translation>
     </message>
     <message>
@@ -517,31 +517,31 @@
     </message>
     <message>
         <source>Sent transaction</source>
-        <translation>処理送信</translation>
+        <translation>送金取引</translation>
     </message>
     <message>
         <source>Incoming transaction</source>
-        <translation>処理受信</translation>
+        <translation>着金取引</translation>
     </message>
     <message>
         <source>HD key generation is &lt;b&gt;enabled&lt;/b&gt;</source>
-        <translation>HDキー世代は&lt;b&gt;有効化&lt;/b&gt;</translation>
+        <translation>HD鍵生成は&lt;b&gt;有効化&lt;/b&gt;されています</translation>
     </message>
     <message>
         <source>HD key generation is &lt;b&gt;disabled&lt;/b&gt;</source>
-        <translation>HDキー世代は&lt;b&gt;無効化&lt;/b&gt;</translation>
+        <translation>HD鍵生成は&lt;b&gt;無効化&lt;/b&gt;されています</translation>
     </message>
     <message>
         <source>Wallet is &lt;b&gt;encrypted&lt;/b&gt; and currently &lt;b&gt;unlocked&lt;/b&gt;</source>
-        <translation>財布は&lt;b&gt;暗号化された&lt;/b&gt; そして現在 &lt;b&gt;ロック解除されています&lt;/b&gt;</translation>
+        <translation>ウォレットは&lt;b&gt;暗号化されて、アンロックされています&lt;/b&gt;</translation>
     </message>
     <message>
         <source>Wallet is &lt;b&gt;encrypted&lt;/b&gt; and currently &lt;b&gt;locked&lt;/b&gt;</source>
-        <translation>財布は &lt;b&gt;暗号化され&lt;/b&gt; そして現在 &lt;b&gt;ロックされています&lt;/b&gt;</translation>
+        <translation>ウォレットは&lt;b&gt;暗号化されて、ロックされています&lt;/b&gt;</translation>
     </message>
     <message>
         <source>A fatal error occurred. Monacoin can no longer continue safely and will quit.</source>
-        <translation>致命的なエラーが発生しました。モナーコインは安全に終了することができません。</translation>
+        <translation>致命的なエラーが発生しました。Monacoin は安全に継続することができず終了するでしょう。</translation>
     </message>
 </context>
 <context>
@@ -552,7 +552,7 @@
     </message>
     <message>
         <source>Quantity:</source>
-        <translation>量:</translation>
+        <translation>数量:</translation>
     </message>
     <message>
         <source>Bytes:</source>
@@ -560,7 +560,7 @@
     </message>
     <message>
         <source>Amount:</source>
-        <translation>残高:</translation>
+        <translation>総額:</translation>
     </message>
     <message>
         <source>Fee:</source>
@@ -568,23 +568,23 @@
     </message>
     <message>
         <source>Dust:</source>
-        <translation>ごみ:</translation>
+        <translation>ダスト：</translation>
     </message>
     <message>
         <source>After Fee:</source>
-        <translation>後の料金:</translation>
+        <translation>手数料差引後:</translation>
     </message>
     <message>
         <source>Change:</source>
-        <translation>変更:</translation>
+        <translation>釣り銭:</translation>
     </message>
     <message>
         <source>(un)select all</source>
-        <translation>全て選択する（しない）</translation>
+        <translation>すべて選択/選択解除</translation>
     </message>
     <message>
         <source>Tree mode</source>
-        <translation>ツリー型</translation>
+        <translation>ツリーモード</translation>
     </message>
     <message>
         <source>List mode</source>
@@ -592,15 +592,15 @@
     </message>
     <message>
         <source>Amount</source>
-        <translation>残高</translation>
+        <translation>総額</translation>
     </message>
     <message>
         <source>Received with label</source>
-        <translation>受信されたラベル</translation>
+        <translation>ラベルに対する入金一覧</translation>
     </message>
     <message>
         <source>Received with address</source>
-        <translation>受信されたアドレス</translation>
+        <translation>アドレスに対する入金一覧</translation>
     </message>
     <message>
         <source>Date</source>
@@ -612,59 +612,59 @@
     </message>
     <message>
         <source>Confirmed</source>
-        <translation>確認済み</translation>
+        <translation>検証数</translation>
     </message>
     <message>
         <source>Copy address</source>
-        <translation>アドレスのコピー</translation>
+        <translation>アドレスをコピーする</translation>
     </message>
     <message>
         <source>Copy label</source>
-        <translation>ラベルのコピー</translation>
+        <translation>ラベルをコピーする</translation>
     </message>
     <message>
         <source>Copy amount</source>
-        <translation>残高のコピー</translation>
+        <translation>総額のコピー</translation>
     </message>
     <message>
         <source>Copy transaction ID</source>
-        <translation>トランザクションIDのコピー</translation>
+        <translation>取引 ID をコピー</translation>
     </message>
     <message>
         <source>Lock unspent</source>
-        <translation>未消費のロック</translation>
+        <translation>未使用トランザクションをロックする</translation>
     </message>
     <message>
         <source>Unlock unspent</source>
-        <translation>未消費のロック解除</translation>
+        <translation>未使用トランザクションをアンロックする</translation>
     </message>
     <message>
         <source>Copy quantity</source>
-        <translation>量をコピー</translation>
+        <translation>数量をコピーする</translation>
     </message>
     <message>
         <source>Copy fee</source>
-        <translation>料金をコピー</translation>
+        <translation>手数料をコピーする</translation>
     </message>
     <message>
         <source>Copy after fee</source>
-        <translation>後料金をこぴー</translation>
+        <translation>手数料差引後の値をコピーする</translation>
     </message>
     <message>
         <source>Copy bytes</source>
-        <translation>バイトをコピー</translation>
+        <translation>バイト数をコピーする</translation>
     </message>
     <message>
         <source>Copy dust</source>
-        <translation>ゴミをコピー</translation>
+        <translation>ダストをコピーする</translation>
     </message>
     <message>
         <source>Copy change</source>
-        <translation>変更をコピー</translation>
+        <translation>釣り銭をコピー</translation>
     </message>
     <message>
         <source>(%1 locked)</source>
-        <translation>(%1 ロック済み)</translation>
+        <translation>(%1 がロック済み)</translation>
     </message>
     <message>
         <source>yes</source>
@@ -676,30 +676,30 @@
     </message>
     <message>
         <source>This label turns red if any recipient receives an amount smaller than the current dust threshold.</source>
-        <translation>受信したレシピが現在のダスト閾値よりも残高が少ない場合、ラベルは赤になります。</translation>
+        <translation>少なくともひとつの受取額が現在のダスト閾値を下回る場合にはこのラベルは赤くなります。</translation>
     </message>
     <message>
         <source>Can vary +/- %1 satoshi(s) per input.</source>
-        <translation>入力ごとにsatoshiの+/- %1に変更できます。</translation>
+        <translation>ひとつの入力につき %1 satoshi 前後ずれることがあります。</translation>
     </message>
     <message>
         <source>(no label)</source>
-        <translation>(ラベルなし)</translation>
+        <translation>（ラベル無し）</translation>
     </message>
     <message>
         <source>change from %1 (%2)</source>
-        <translation>%1 (%2)から変更</translation>
+        <translation>%1 (%2) からのおつり</translation>
     </message>
     <message>
         <source>(change)</source>
-        <translation>(変更)</translation>
+        <translation>(おつり)</translation>
     </message>
 </context>
 <context>
     <name>EditAddressDialog</name>
     <message>
         <source>Edit Address</source>
-        <translation>アドレス編集</translation>
+        <translation>アドレスの編集</translation>
     </message>
     <message>
         <source>&amp;Label</source>
@@ -707,54 +707,54 @@
     </message>
     <message>
         <source>The label associated with this address list entry</source>
-        <translation>ラベルに結合されたアドレスのリストエントリー</translation>
+        <translation>このアドレス帳項目に結びつけられているラベル</translation>
     </message>
     <message>
         <source>The address associated with this address list entry. This can only be modified for sending addresses.</source>
-        <translation>アドレスに結合されたアドレスリストのエントリーです。これは送信アドレスのみによって変更されます。</translation>
+        <translation>このアドレス帳項目に結びつけられているアドレス。この項目は送金用アドレスの場合のみ編集することができます。</translation>
     </message>
     <message>
         <source>&amp;Address</source>
-        <translation>&amp;アドレス</translation>
+        <translation>アドレス帳 (&amp;A)</translation>
     </message>
     <message>
         <source>New receiving address</source>
-        <translation>新規の受信アドレス</translation>
+        <translation>新しい受信アドレス</translation>
     </message>
     <message>
         <source>New sending address</source>
-        <translation>新規の送信アドレス</translation>
+        <translation>新しい送信アドレス</translation>
     </message>
     <message>
         <source>Edit receiving address</source>
-        <translation>受信アドレスを編集</translation>
+        <translation>入金アドレスを編集</translation>
     </message>
     <message>
         <source>Edit sending address</source>
-        <translation>送信アドレスの編集</translation>
+        <translation>送信アドレスを編集</translation>
     </message>
     <message>
         <source>The entered address "%1" is not a valid Monacoin address.</source>
-        <translation>入寮されたアドレス "%1" は正当なモナーコインアドレスではありません。</translation>
+        <translation>入力されたアドレス "%1" は無効な Monacoin アドレスです。</translation>
     </message>
     <message>
         <source>The entered address "%1" is already in the address book.</source>
-        <translation>入浴されたアドレス "%1" はすでにアドレス帳にあります。</translation>
+        <translation>入力されたアドレス "%1" は既にアドレス帳にあります。</translation>
     </message>
     <message>
         <source>Could not unlock wallet.</source>
-        <translation>財布をロック解除できませんでした。</translation>
+        <translation>ウォレットをアンロックできませんでした。</translation>
     </message>
     <message>
         <source>New key generation failed.</source>
-        <translation>新規のキー生成に失敗しました。</translation>
+        <translation>新しいキーの生成に失敗しました。</translation>
     </message>
 </context>
 <context>
     <name>FreespaceChecker</name>
     <message>
         <source>A new data directory will be created.</source>
-        <translation>新しい日付の辞書が作成されるでしょう。</translation>
+        <translation>新しいデータ ディレクトリが作成されます。</translation>
     </message>
     <message>
         <source>name</source>
@@ -762,15 +762,15 @@
     </message>
     <message>
         <source>Directory already exists. Add %1 if you intend to create a new directory here.</source>
-        <translation>辞書はすでに存在しています。新しい辞書を作成する場合は、%1を追加してください。</translation>
+        <translation>ディレクトリがもうあります。 新しいのディレクトリを作るつもりなら%1を書いてください。</translation>
     </message>
     <message>
         <source>Path already exists, and is not a directory.</source>
-        <translation>パスはすでに存在しており、辞書ではありません。</translation>
+        <translation>パスが存在しますがディレクトリではありません。</translation>
     </message>
     <message>
         <source>Cannot create data directory here.</source>
-        <translation>ここに日付辞書を作成することはできません。</translation>
+        <translation>ここにデータ ディレクトリを作成することはできません。</translation>
     </message>
 </context>
 <context>
@@ -781,23 +781,23 @@
     </message>
     <message>
         <source>(%1-bit)</source>
-        <translation>(%1-ビット)</translation>
+        <translation>(%1ビット)</translation>
     </message>
     <message>
         <source>About %1</source>
-        <translation>%1について</translation>
+        <translation>%1 について</translation>
     </message>
     <message>
         <source>Command-line options</source>
-        <translation>コマンドラインオプション</translation>
+        <translation>コマンドライン オプション</translation>
     </message>
     <message>
         <source>Usage:</source>
-        <translation>使用方法:</translation>
+        <translation>使用法:</translation>
     </message>
     <message>
         <source>command-line options</source>
-        <translation>コマンドラインオプション:</translation>
+        <translation>コマンドライン オプション</translation>
     </message>
     <message>
         <source>UI Options:</source>
@@ -805,27 +805,27 @@
     </message>
     <message>
         <source>Choose data directory on startup (default: %u)</source>
-        <translation>起動の日付辞書の選択 (デフォルト: %u)</translation>
+        <translation>起動時にデータ ディレクトリを選ぶ (初期値: %u)</translation>
     </message>
     <message>
         <source>Set language, for example "de_DE" (default: system locale)</source>
-        <translation>言語設定, 例 "de_DE" (デフォルト: システムロケール)</translation>
+        <translation>言語設定 例: "de_DE" (初期値: システムの言語)</translation>
     </message>
     <message>
         <source>Start minimized</source>
-        <translation>最小化起動</translation>
+        <translation>最小化された状態で起動する</translation>
     </message>
     <message>
         <source>Set SSL root certificates for payment request (default: -system-)</source>
-        <translation>支払要求のSSLルート証明の設定 (デフォルト: -システム-)</translation>
+        <translation>支払いリクエスト用にSSLルート証明書を設定する (デフォルト：-system-)</translation>
     </message>
     <message>
         <source>Show splash screen on startup (default: %u)</source>
-        <translation>起動スクリーンを表示 (デフォルト: %u)</translation>
+        <translation>起動時にスプラッシュ画面を表示する (初期値: %u)</translation>
     </message>
     <message>
         <source>Reset all settings changed in the GUI</source>
-        <translation>GUIのすべての設定をリセット</translation>
+        <translation>GUI で行われた設定の変更を全てリセット</translation>
     </message>
 </context>
 <context>
@@ -836,23 +836,23 @@
     </message>
     <message>
         <source>Welcome to %1.</source>
-        <translation>ようこそ  %1.</translation>
+        <translation>%1 へようこそ。</translation>
     </message>
     <message>
         <source>As this is the first time the program is launched, you can choose where %1 will store its data.</source>
-        <translation>プログラムの初回起動時なので、データの保存場所 %1を選択してください。</translation>
+        <translation>これはプログラム最初の起動です。%1 がデータを保存する場所を選択して下さい。</translation>
     </message>
     <message>
         <source>Use the default data directory</source>
-        <translation>デフォルトデータ辞書を使用</translation>
+        <translation>初期値のデータ ディレクトリを使用</translation>
     </message>
     <message>
         <source>Use a custom data directory:</source>
-        <translation>カスタムデータ辞書を使用</translation>
+        <translation>任意のデータ ディレクトリを使用:</translation>
     </message>
     <message>
         <source>Error: Specified data directory "%1" cannot be created.</source>
-        <translation>エラー: 特定の辞書%1の作成に失敗しました。</translation>
+        <translation>エラー: 指定のデータディレクトリ "%1" を作成できません。</translation>
     </message>
     <message>
         <source>Error</source>
@@ -867,11 +867,11 @@
     </message>
     <message>
         <source>Recent transactions may not yet be visible, and therefore your wallet's balance might be incorrect. This information will be correct once your wallet has finished synchronizing with the monacoin network, as detailed below.</source>
-        <translation>最近のトランザクションが表示できない可能性があります。従って、ウォレットの残高が正しくない可能性があります。この情報はモナーコインネットワークに接続し、同期処理を完了させると正しくなります。詳細は以下になります。</translation>
+        <translation>確認できない最近のトランザクションがあるかもしれません。これによりウォレットの残高は不正確なものである可能性があります。この情報はウォレットが一度モナーコインネットワークへの同期が完了すると正確なものとなります。詳細は下記を参照してください。</translation>
     </message>
     <message>
         <source>Attempting to spend monacoins that are affected by not-yet-displayed transactions will not be accepted by the network.</source>
-        <translation>使用したモナーコインで、未処理となっているものは、ネットワークによって受領されません。</translation>
+        <translation>まだ表示されていないトランザクションが影響するモナーコインを使用しようとすると、ネットワークから認証がなされないでしょう。</translation>
     </message>
     <message>
         <source>Number of blocks left</source>
@@ -879,27 +879,27 @@
     </message>
     <message>
         <source>Unknown...</source>
-        <translation>不明...</translation>
+        <translation>未知...</translation>
     </message>
     <message>
         <source>Last block time</source>
-        <translation>最後のブロック時間</translation>
+        <translation>最終ブロックの日時</translation>
     </message>
     <message>
         <source>Progress</source>
-        <translation>実行</translation>
+        <translation>進捗</translation>
     </message>
     <message>
         <source>Progress increase per hour</source>
-        <translation>時間ごとの実行増加</translation>
+        <translation>進捗状況は一時間ごとに増加します</translation>
     </message>
     <message>
         <source>calculating...</source>
-        <translation>計算中...</translation>
+        <translation>計算しています...</translation>
     </message>
     <message>
         <source>Estimated time left until synced</source>
-        <translation>同期化完了までの予測時間</translation>
+        <translation>同期完了までの推定残り時間</translation>
     </message>
     <message>
         <source>Hide</source>
@@ -907,18 +907,18 @@
     </message>
     <message>
         <source>Unknown. Syncing Headers (%1)...</source>
-        <translation>不明. ヘッダーの同期中 (%1)...</translation>
+        <translation>未知。ヘッダを同期しています (%1)...</translation>
     </message>
 </context>
 <context>
     <name>OpenURIDialog</name>
     <message>
         <source>Open URI</source>
-        <translation>オープンURI</translation>
+        <translation>URI を開く</translation>
     </message>
     <message>
         <source>Open payment request from URI or file</source>
-        <translation>URLもしくはファイルからの支払い要求を開く</translation>
+        <translation>URI またはファイルから支払いリクエストを開く</translation>
     </message>
     <message>
         <source>URI:</source>
@@ -926,138 +926,138 @@
     </message>
     <message>
         <source>Select payment request file</source>
-        <translation>支払い要求ファイルの選択</translation>
+        <translation>支払いリクエストファイルを選択してください</translation>
     </message>
     <message>
         <source>Select payment request file to open</source>
-        <translation>開く支払い要求ファイルを選択</translation>
+        <translation>開きたい支払いリクエストファイルを選択してください</translation>
     </message>
 </context>
 <context>
     <name>OptionsDialog</name>
     <message>
         <source>Options</source>
-        <translation>オプション</translation>
+        <translation>設定</translation>
     </message>
     <message>
         <source>&amp;Main</source>
-        <translation>&amp;メイン</translation>
+        <translation>メイン (&amp;M)</translation>
     </message>
     <message>
         <source>Automatically start %1 after logging in to the system.</source>
-        <translation>システムログイン時に%1を自動的に開始</translation>
+        <translation>システムにログインした際、自動的に %1 を起動する。</translation>
     </message>
     <message>
         <source>&amp;Start %1 on system login</source>
-        <translation>&amp;システムログインで%1を開始</translation>
+        <translation>システムにログインした時に %1 を起動 (&amp;S)</translation>
     </message>
     <message>
         <source>Size of &amp;database cache</source>
-        <translation>&amp;データベース喝取のサイズ</translation>
+        <translation>データベースキャッシュのサイズ (&amp;D)</translation>
     </message>
     <message>
         <source>MB</source>
-        <translation>メガバイト</translation>
+        <translation>MB</translation>
     </message>
     <message>
         <source>Number of script &amp;verification threads</source>
-        <translation>&amp;認証スレッドスクリプトの数</translation>
+        <translation>スクリプト検証用スレッド数 (&amp;V)</translation>
     </message>
     <message>
         <source>Accept connections from outside</source>
-        <translation>外部からの接続承認</translation>
+        <translation>外部からの接続を許可する</translation>
     </message>
     <message>
         <source>Allow incoming connections</source>
-        <translation>内部接続の許可</translation>
+        <translation>外部からの接続を許可する</translation>
     </message>
     <message>
         <source>IP address of the proxy (e.g. IPv4: 127.0.0.1 / IPv6: ::1)</source>
-        <translation>IP プロキシのアドレス (例 IPv4: 127.0.0.1 / IPv6: ::1)</translation>
+        <translation>プロキシのIPアドレス (例えば IPv4: 127.0.0.1 / IPv6: ::1)</translation>
     </message>
     <message>
         <source>Minimize instead of exit the application when the window is closed. When this option is enabled, the application will be closed only after selecting Exit in the menu.</source>
-        <translation>ウィンドウが閉じられた時、アプリケーションを終了せずに最小化します。オプションボタンが有効な時は、アプリケーションはメニューの終了が選択されら時のみ、終了します。</translation>
+        <translation>ウィンドウを閉じる際にアプリケーションを終了するのではなく、最小化します。このオプションが有効化された場合、メニューから終了を選択した場合にのみアプリケーションは閉じられます。</translation>
     </message>
     <message>
         <source>Third party URLs (e.g. a block explorer) that appear in the transactions tab as context menu items. %s in the URL is replaced by transaction hash. Multiple URLs are separated by vertical bar |.</source>
-        <translation>サードパーティのURL(例 a block explorer)はコンテキストメニューアイテムの処理タブに表示されます。YRLの%sは処理ハッシュによって置き換えられます。複数URLは水平バー | によって区切られます。</translation>
+        <translation>トランザクションタブのコンテキストメニュー項目に表示する、サードパーティURL (例えばブロックエクスプローラ)。URL中の%sはトランザクションのハッシュ値に置き換えられます。垂直バー | で区切ることで、複数のURLを指定できます。</translation>
     </message>
     <message>
         <source>Third party transaction URLs</source>
-        <translation>サードパティ処理URL</translation>
+        <translation>サードパーティのトランザクションURL</translation>
     </message>
     <message>
         <source>Active command-line options that override above options:</source>
-        <translation>オプション上書きのコマンドラインオプションの有効化</translation>
+        <translation>上のオプションを置き換えることのできる、有効なコマンドラインオプションの一覧:</translation>
     </message>
     <message>
         <source>Reset all client options to default.</source>
-        <translation>全てのクライアントオプションをデフォルトにリセット</translation>
+        <translation>すべてのオプションを初期値に戻します。</translation>
     </message>
     <message>
         <source>&amp;Reset Options</source>
-        <translation>&amp;リセットオプション</translation>
+        <translation>オプションをリセット (&amp;R)</translation>
     </message>
     <message>
         <source>&amp;Network</source>
-        <translation>&amp;ネットワーク</translation>
+        <translation>ネットワーク (&amp;N)</translation>
     </message>
     <message>
         <source>(0 = auto, &lt;0 = leave that many cores free)</source>
-        <translation>(0 = 自動, &lt;0 = 使用しないコア数)</translation>
+        <translation>(0 = 自動、0以上 = 指定した数のコアをフリーにする)</translation>
     </message>
     <message>
         <source>W&amp;allet</source>
-        <translation>ウォレット</translation>
+        <translation>ウォレット (&amp;A)</translation>
     </message>
     <message>
         <source>Expert</source>
-        <translation>専門家</translation>
+        <translation>上級者向け</translation>
     </message>
     <message>
         <source>Enable coin &amp;control features</source>
-        <translation>コインと制御機能の有効化</translation>
+        <translation>コインコントロール機能を有効化する (&amp;C)</translation>
     </message>
     <message>
         <source>If you disable the spending of unconfirmed change, the change from a transaction cannot be used until that transaction has at least one confirmation. This also affects how your balance is computed.</source>
-        <translation>認証されていない変更の支出を無効化した場合、その変更を含む処理はすべての認証が完了するまで、使用することはできません。また、これは残高の計算にも影響します。</translation>
+        <translation>未検証のおつりの使用を無効化すると、トランザクションが少なくとも1検証を獲得するまではそのトランザクションのおつりは利用できなくなります。これは残高の計算方法にも影響します。</translation>
     </message>
     <message>
         <source>&amp;Spend unconfirmed change</source>
-        <translation>&amp;認証されていない変更の支払い</translation>
+        <translation>未検証のおつりを使用する (&amp;S)</translation>
     </message>
     <message>
         <source>Automatically open the Monacoin client port on the router. This only works when your router supports UPnP and it is enabled.</source>
-        <translation>自動絵的にルータのモナーコインのクライアントポートが開きます。この機能はルータがUPnPをサポートし、有効であるときに動作します。</translation>
+        <translation>自動的にルーター上の Monacoin クライアントのポートを開きます。あなたのルーターが UPnP に対応していて、それが有効になっている場合に作動します。</translation>
     </message>
     <message>
         <source>Map port using &amp;UPnP</source>
-        <translation>&amp;UPnPを使用してポート配置します。</translation>
+        <translation>UPnP を使ってポートを割り当てる (&amp;U)</translation>
     </message>
     <message>
         <source>Connect to the Monacoin network through a SOCKS5 proxy.</source>
-        <translation>SOCKS5プロキシを使用してモナーコインネットワークへ接続</translation>
+        <translation>SOCKS5 プロキシ経由でMonacoinネットワークに接続する</translation>
     </message>
     <message>
         <source>&amp;Connect through SOCKS5 proxy (default proxy):</source>
-        <translation>&amp;SOCKS5プロキシを使用して接続 (デフォルト プロキシ):</translation>
+        <translation>SOCKS5 プロキシ経由で接続する (デフォルトプロキシ): (&amp;C)</translation>
     </message>
     <message>
         <source>Proxy &amp;IP:</source>
-        <translation>プロキシ &amp;IP:</translation>
+        <translation>プロキシの IP (&amp;I) :</translation>
     </message>
     <message>
         <source>&amp;Port:</source>
-        <translation>&amp;ポート:</translation>
+        <translation>ポート (&amp;P) :</translation>
     </message>
     <message>
         <source>Port of the proxy (e.g. 9050)</source>
-        <translation>プロキシのポート (例 9050)</translation>
+        <translation>プロキシのポート番号 (例 9050)</translation>
     </message>
     <message>
         <source>Used for reaching peers via:</source>
-        <translation>ピア経由での使用:</translation>
+        <translation>ピアへ到達するために使われた方法:</translation>
     </message>
     <message>
         <source>IPv4</source>
@@ -1073,59 +1073,59 @@
     </message>
     <message>
         <source>Connect to the Monacoin network through a separate SOCKS5 proxy for Tor hidden services.</source>
-        <translation>Tor秘匿ネットワークのための区切られたSOCKS5を経由して、モナーコインネットワークに接続</translation>
+        <translation>Tor秘匿サービスを利用するため、独立なSOCKS5プロキシ経由でMonacoinネットワークに接続する</translation>
     </message>
     <message>
         <source>Use separate SOCKS5 proxy to reach peers via Tor hidden services:</source>
-        <translation>Tor匿名サービスを経由して到達ピアへ、区切られたSOCKS5 プロキシを使用:</translation>
+        <translation>Tor秘匿サービス経由でピアに到達するため、独立なSOCKS5プロキシを利用する:</translation>
     </message>
     <message>
         <source>&amp;Window</source>
-        <translation>&amp;画面</translation>
+        <translation>ウインドウ (&amp;W)</translation>
     </message>
     <message>
         <source>&amp;Hide the icon from the system tray.</source>
-        <translation>&amp;システムトレイのアイコンを非表示.</translation>
+        <translation>システムトレイのアイコンを隠す (&amp;H)</translation>
     </message>
     <message>
         <source>Hide tray icon</source>
-        <translation>トレイアイコンを非表示</translation>
+        <translation>トレイアイコンを隠す</translation>
     </message>
     <message>
         <source>Show only a tray icon after minimizing the window.</source>
-        <translation>画面最小化時にトレイアイコンを表示する。</translation>
+        <translation>ウインドウを最小化したあとトレイ アイコンだけを表示する。</translation>
     </message>
     <message>
         <source>&amp;Minimize to the tray instead of the taskbar</source>
-        <translation>&amp;ツールバーの代わりにトレイへ最小化</translation>
+        <translation>タスクバーの代わりにトレイに最小化 (&amp;M)</translation>
     </message>
     <message>
         <source>M&amp;inimize on close</source>
-        <translation>クローズで最小化</translation>
+        <translation>閉じる時に最小化 (&amp;i)</translation>
     </message>
     <message>
         <source>&amp;Display</source>
-        <translation>&amp;画面</translation>
+        <translation>表示 (&amp;D)</translation>
     </message>
     <message>
         <source>User Interface &amp;language:</source>
-        <translation>ユーザインターフェース &amp;言語:</translation>
+        <translation>ユーザインターフェースの言語 (&amp;l) :</translation>
     </message>
     <message>
         <source>The user interface language can be set here. This setting will take effect after restarting %1.</source>
-        <translation>ユーザインタフェースの言語はここで設定されます。設定は%1を再起動後、有効になります。</translation>
+        <translation>ここでユーザインターフェースの言語を設定できます。設定を反映するには %1 を再起動します。</translation>
     </message>
     <message>
         <source>&amp;Unit to show amounts in:</source>
-        <translation>&amp;残高表示の単位:</translation>
+        <translation>額を表示する単位 (&amp;U) :</translation>
     </message>
     <message>
         <source>Choose the default subdivision unit to show in the interface and when sending coins.</source>
-        <translation>コイン送付時のインターフェースに表示するデフォルトの除算単位の選択</translation>
+        <translation>インターフェース上の表示とコインの送信で使用する単位を選択します。</translation>
     </message>
     <message>
         <source>Whether to show coin control features or not.</source>
-        <translation>コイン制御機能を表示するかどうか。</translation>
+        <translation>コインコントロール機能を表示するかどうか。</translation>
     </message>
     <message>
         <source>&amp;OK</source>
@@ -1137,7 +1137,7 @@
     </message>
     <message>
         <source>default</source>
-        <translation>デフォルト</translation>
+        <translation>初期値</translation>
     </message>
     <message>
         <source>none</source>
@@ -1145,23 +1145,23 @@
     </message>
     <message>
         <source>Confirm options reset</source>
-        <translation>オプションリセットの確認</translation>
+        <translation>オプションのリセットの確認</translation>
     </message>
     <message>
         <source>Client restart required to activate changes.</source>
-        <translation>変更を有効にするため、クライアントの再起動が必要です。</translation>
+        <translation>変更を有効化するにはクライアントを再起動する必要があります。</translation>
     </message>
     <message>
         <source>Client will be shut down. Do you want to proceed?</source>
-        <translation>クライアントは停止します。継続してもよろしいでしょうか？</translation>
+        <translation>クライアントを終了します。続行してもよろしいですか？</translation>
     </message>
     <message>
         <source>This change would require a client restart.</source>
-        <translation>変更は、クライアントの再起動が必要になる場合があります。</translation>
+        <translation>この変更はクライアントの再起動が必要です。</translation>
     </message>
     <message>
         <source>The supplied proxy address is invalid.</source>
-        <translation>提供されたプロキシアドレスは無効です。</translation>
+        <translation>プロキシアドレスが無効です。</translation>
     </message>
 </context>
 <context>
@@ -1172,27 +1172,27 @@
     </message>
     <message>
         <source>The displayed information may be out of date. Your wallet automatically synchronizes with the Monacoin network after a connection is established, but this process has not completed yet.</source>
-        <translation>表示されている情報は、期限切れの可能性があります。ウォレットは自動的にモナーコインネットワークへの接続が確立した後に同期化されます。しかし、処理はまだ、完了していません。</translation>
+        <translation>表示された情報は古いかもしれません。接続が確立されると、あなたのウォレットは Monacoin ネットワークと自動的に同期しますが、このプロセスはまだ完了していません。</translation>
     </message>
     <message>
         <source>Watch-only:</source>
-        <translation>読み取り専用:</translation>
+        <translation>監視限定:</translation>
     </message>
     <message>
         <source>Available:</source>
-        <translation>有効:</translation>
+        <translation>利用可能:</translation>
     </message>
     <message>
         <source>Your current spendable balance</source>
-        <translation>現在の支払い可能な残高</translation>
+        <translation>あなたの利用可能残高</translation>
     </message>
     <message>
         <source>Pending:</source>
-        <translation>未決定:</translation>
+        <translation>検証待ち:</translation>
     </message>
     <message>
         <source>Total of transactions that have yet to be confirmed, and do not yet count toward the spendable balance</source>
-        <translation>全てのトランザクションはまだ、確認されておらず、支払い可能な残高も数えられていません。</translation>
+        <translation>未検証の取引で利用可能残高に反映されていない数</translation>
     </message>
     <message>
         <source>Immature:</source>
@@ -1200,7 +1200,7 @@
     </message>
     <message>
         <source>Mined balance that has not yet matured</source>
-        <translation>まだ、完成していない、採掘された残高</translation>
+        <translation>完成していない採掘された残高</translation>
     </message>
     <message>
         <source>Balances</source>
@@ -1212,70 +1212,70 @@
     </message>
     <message>
         <source>Your current total balance</source>
-        <translation>現在の合計残高</translation>
+        <translation>あなたの現在の残高</translation>
     </message>
     <message>
         <source>Your current balance in watch-only addresses</source>
-        <translation>読み取り専用アドレス内の現在の残高</translation>
+        <translation>監視限定アドレス内の現在の残高</translation>
     </message>
     <message>
         <source>Spendable:</source>
-        <translation>支払い可能:</translation>
+        <translation>使用可能:</translation>
     </message>
     <message>
         <source>Recent transactions</source>
-        <translation>最近の処理</translation>
+        <translation>最近のトランザクション</translation>
     </message>
     <message>
         <source>Unconfirmed transactions to watch-only addresses</source>
-        <translation>読み取り専用アドレスへの未確認の処理</translation>
+        <translation>監視限定アドレスに対する未検証のトランザクション</translation>
     </message>
     <message>
         <source>Mined balance in watch-only addresses that has not yet matured</source>
-        <translation>まだ、完成していない、読み取り専用アドレスの中の発掘された残高</translation>
+        <translation>監視限定アドレスの採掘された残高のうち、成熟していないもの</translation>
     </message>
     <message>
         <source>Current total balance in watch-only addresses</source>
-        <translation>読み取り専用アドレス内の現在の合計残高</translation>
+        <translation>監視限定アドレス内の現在の全残高</translation>
     </message>
 </context>
 <context>
     <name>PaymentServer</name>
     <message>
         <source>Payment request error</source>
-        <translation>支払い要求エラー</translation>
+        <translation>支払いのリクエストのエラーです</translation>
     </message>
     <message>
         <source>Cannot start monacoin: click-to-pay handler</source>
-        <translation>モナーコインを開始できません: click-to-pay handler</translation>
+        <translation>Monacoin を起動できません: click-to-pay handler</translation>
     </message>
     <message>
         <source>URI handling</source>
-        <translation>URI ハンドリング</translation>
+        <translation>URI の操作</translation>
     </message>
     <message>
         <source>Payment request fetch URL is invalid: %1</source>
-        <translation>取得した支払要求は無効です: %1</translation>
+        <translation>支払いリクエストの取得先URLが無効です: %1</translation>
     </message>
     <message>
         <source>Invalid payment address %1</source>
-        <translation>無効な支払アドレス %1</translation>
+        <translation>支払いのアドレス「%1」は無効です</translation>
     </message>
     <message>
         <source>URI cannot be parsed! This can be caused by an invalid Monacoin address or malformed URI parameters.</source>
-        <translation>URLはパースできませんでした! 原因はモナーコインアドレスが無効であるか、URIパラメータの形式が間違っている可能性があります。</translation>
+        <translation>支払いリクエストファイルを読み込めませんでした！無効な支払いリクエストファイルにより引き起こされた可能性があります。</translation>
     </message>
     <message>
         <source>Payment request file handling</source>
-        <translation>支払要求ファイル操作</translation>
+        <translation>支払いリクエストは拒否されました</translation>
     </message>
     <message>
         <source>Payment request file cannot be read! This can be caused by an invalid payment request file.</source>
-        <translation>支払要求ファイルが読み込めませんでした! 支払要求ファイルが無効である可能性があります。</translation>
+        <translation>支払いリクエストのネットワークは現在のクライアントのネットワークに一致しません。</translation>
     </message>
     <message>
         <source>Payment request rejected</source>
-        <translation>支払要求却下</translation>
+        <translation>支払いリクエストの期限が切れました。</translation>
     </message>
     <message>
         <source>Payment request network doesn't match client network.</source>
@@ -1283,7 +1283,7 @@
     </message>
     <message>
         <source>Payment request expired.</source>
-        <translation>支払要求期限切れ</translation>
+        <translation>支払いリクエストは開始されていません。</translation>
     </message>
     <message>
         <source>Payment request is not initialized.</source>
@@ -1291,43 +1291,43 @@
     </message>
     <message>
         <source>Unverified payment requests to custom payment scripts are unsupported.</source>
-        <translation>カスタム支払スクリプトへの未検証の支払要求は、サポートされていません。</translation>
+        <translation>カスタム支払いスクリプトに対する、検証されていない支払いリクエストはサポートされていません。</translation>
     </message>
     <message>
         <source>Invalid payment request.</source>
-        <translation>無効な支払要求:</translation>
+        <translation>無効な支払いリクエスト。</translation>
     </message>
     <message>
         <source>Requested payment amount of %1 is too small (considered dust).</source>
-        <translation>要求支払額%1は小さすぎます (ダストを検討してください).</translation>
+        <translation>支払リクエスト %1 は少なすぎます (ダストとみなされてしまいます)。</translation>
     </message>
     <message>
         <source>Refund from %1</source>
-        <translation>%1からの払い戻し</translation>
+        <translation>%1 からの返金</translation>
     </message>
     <message>
         <source>Payment request %1 is too large (%2 bytes, allowed %3 bytes).</source>
-        <translation>支払要求 %1 は大きすぎます (%2 バイト, %3 バイトまで許可).</translation>
+        <translation>支払リクエスト %1 は大きすぎます（%2バイトですが、%3バイトまでが許されています）。</translation>
     </message>
     <message>
         <source>Error communicating with %1: %2</source>
-        <translation>通信エラー:%1 :%2</translation>
+        <translation>%1: %2と通信エラーです</translation>
     </message>
     <message>
         <source>Payment request cannot be parsed!</source>
-        <translation>支払要求は解析できませんでした!</translation>
+        <translation>支払リクエストを読み込めませんでした！</translation>
     </message>
     <message>
         <source>Bad response from server %1</source>
-        <translation>サーバ%1からの不正なレスポンス</translation>
+        <translation>サーバーの応答が無効 %1</translation>
     </message>
     <message>
         <source>Network request error</source>
-        <translation>ネットワーク要求エラー</translation>
+        <translation>ネットワーク要求エラーです</translation>
     </message>
     <message>
         <source>Payment acknowledged</source>
-        <translation>認証済み支払</translation>
+        <translation>支払いは確認しました</translation>
     </message>
 </context>
 <context>
@@ -1353,27 +1353,27 @@
     <name>QObject</name>
     <message>
         <source>Amount</source>
-        <translation>残高</translation>
+        <translation>総額</translation>
     </message>
     <message>
         <source>Enter a Monacoin address (e.g. %1)</source>
-        <translation>モナーコインアドレスの入力 (例 %1)</translation>
+        <translation>Monacoinアドレスを入力してください (例 %1)</translation>
     </message>
     <message>
         <source>%1 d</source>
-        <translation>%1 d</translation>
+        <translation>%1日</translation>
     </message>
     <message>
         <source>%1 h</source>
-        <translation>%1 h</translation>
+        <translation>%1時間</translation>
     </message>
     <message>
         <source>%1 m</source>
-        <translation>%1 m</translation>
+        <translation>%1分</translation>
     </message>
     <message>
         <source>%1 s</source>
-        <translation>%1 s</translation>
+        <translation>%1秒</translation>
     </message>
     <message>
         <source>None</source>
@@ -1381,11 +1381,11 @@
     </message>
     <message>
         <source>N/A</source>
-        <translation>該当なし</translation>
+        <translation>N/A</translation>
     </message>
     <message>
         <source>%1 ms</source>
-        <translation>%1 ms</translation>
+        <translation>%1ミリ秒</translation>
     </message>
     <message>
         <source>%1 and %2</source>
@@ -1393,18 +1393,18 @@
     </message>
     <message>
         <source>%1 didn't yet exit safely...</source>
-        <translation>%1 は安全に終了できませんでした...</translation>
+        <translation>%1 はまだ安全に終了していません...</translation>
     </message>
 </context>
 <context>
     <name>QObject::QObject</name>
     <message>
         <source>Error: Specified data directory "%1" does not exist.</source>
-        <translation>エラー: 特定の日付辞書 "%1" は存在しません。</translation>
+        <translation>エラー: 指定のデータ ディレクトリ "%1" は存在しません。</translation>
     </message>
     <message>
         <source>Error: Cannot parse configuration file: %1. Only use key=value syntax.</source>
-        <translation>エラー: 構成ファイルが解析できませんでした: %1. キー=値の構文のみが使用できます。</translation>
+        <translation>エラー: 設定ファイルをパースできません: %1。key=value という記法のみを利用してください。</translation>
     </message>
     <message>
         <source>Error: %1</source>
@@ -1415,38 +1415,38 @@
     <name>QRImageWidget</name>
     <message>
         <source>&amp;Save Image...</source>
-        <translation>&amp;イメージ保存...</translation>
+        <translation>画像を保存(&amp;S)</translation>
     </message>
     <message>
         <source>&amp;Copy Image</source>
-        <translation>&amp;イメージコピー</translation>
+        <translation>画像をコピー(&amp;C)</translation>
     </message>
     <message>
         <source>Save QR Code</source>
-        <translation>QRコード保存</translation>
+        <translation>QR コードの保存</translation>
     </message>
     <message>
         <source>PNG Image (*.png)</source>
-        <translation>PNGイメージ(*.png)</translation>
+        <translation>PNG画像ファイル(*.png)</translation>
     </message>
 </context>
 <context>
     <name>RPCConsole</name>
     <message>
         <source>N/A</source>
-        <translation>該当なし</translation>
+        <translation>N/A</translation>
     </message>
     <message>
         <source>Client version</source>
-        <translation>クライアントバージョン</translation>
+        <translation>クライアントのバージョン</translation>
     </message>
     <message>
         <source>&amp;Information</source>
-        <translation>&amp;情報</translation>
+        <translation>情報 (&amp;I)</translation>
     </message>
     <message>
         <source>Debug window</source>
-        <translation>デバッグ画面</translation>
+        <translation>デバッグ ウインドウ</translation>
     </message>
     <message>
         <source>General</source>
@@ -1454,7 +1454,7 @@
     </message>
     <message>
         <source>Using BerkeleyDB version</source>
-        <translation>BerkeleyDBバージョンの使用</translation>
+        <translation>使用中のBerkleyDBバージョン</translation>
     </message>
     <message>
         <source>Datadir</source>
@@ -1462,7 +1462,7 @@
     </message>
     <message>
         <source>Startup time</source>
-        <translation>開始時間</translation>
+        <translation>起動した日時</translation>
     </message>
     <message>
         <source>Network</source>
@@ -1478,7 +1478,7 @@
     </message>
     <message>
         <source>Block chain</source>
-        <translation>ブロックチェーン</translation>
+        <translation>ブロック チェーン</translation>
     </message>
     <message>
         <source>Current number of blocks</source>
@@ -1486,11 +1486,11 @@
     </message>
     <message>
         <source>Memory Pool</source>
-        <translation>メモリプール</translation>
+        <translation>メモリ・プール</translation>
     </message>
     <message>
         <source>Current number of transactions</source>
-        <translation>現在の処理数</translation>
+        <translation>現在のトランザクション数</translation>
     </message>
     <message>
         <source>Memory usage</source>
@@ -1498,27 +1498,27 @@
     </message>
     <message>
         <source>Received</source>
-        <translation>受信済み</translation>
+        <translation>受取</translation>
     </message>
     <message>
         <source>Sent</source>
-        <translation>送信済み</translation>
+        <translation>送金</translation>
     </message>
     <message>
         <source>&amp;Peers</source>
-        <translation>&amp;ピア</translation>
+        <translation>ピア (&amp;P)</translation>
     </message>
     <message>
         <source>Banned peers</source>
-        <translation>禁止ピア</translation>
+        <translation>Banされたピア</translation>
     </message>
     <message>
         <source>Select a peer to view detailed information.</source>
-        <translation>詳細情報を表示するピアの選択</translation>
+        <translation>詳しい情報を見たいピアを選択してください。</translation>
     </message>
     <message>
         <source>Whitelisted</source>
-        <translation>ホワイトリスト済み</translation>
+        <translation>ホワイトリスト</translation>
     </message>
     <message>
         <source>Direction</source>
@@ -1530,15 +1530,15 @@
     </message>
     <message>
         <source>Starting Block</source>
-        <translation>ブロック開始中</translation>
+        <translation>開始ブロック</translation>
     </message>
     <message>
         <source>Synced Headers</source>
-        <translation>同期化されたヘッダー</translation>
+        <translation>同期済みヘッダ</translation>
     </message>
     <message>
         <source>Synced Blocks</source>
-        <translation>同期化されたブロック</translation>
+        <translation>同期済みブロック</translation>
     </message>
     <message>
         <source>User Agent</source>
@@ -1546,15 +1546,15 @@
     </message>
     <message>
         <source>Open the %1 debug log file from the current data directory. This can take a few seconds for large log files.</source>
-        <translation>現在のデータ辞書から%1デバッグログファイルを開きます。ログファイルが大きいため、数秒かかります。</translation>
+        <translation>現在のデータディレクトリから %1 のデバッグ用ログファイルを開きます。ログファイルが巨大な場合、数秒かかることがあります。</translation>
     </message>
     <message>
         <source>Decrease font size</source>
-        <translation>フォントサイズの縮小</translation>
+        <translation>文字サイズを縮小</translation>
     </message>
     <message>
         <source>Increase font size</source>
-        <translation>フォントサイズの拡大</translation>
+        <translation>文字サイズを拡大</translation>
     </message>
     <message>
         <source>Services</source>
@@ -1562,7 +1562,7 @@
     </message>
     <message>
         <source>Ban Score</source>
-        <translation>禁止スコア</translation>
+        <translation>Banスコア</translation>
     </message>
     <message>
         <source>Connection Time</source>
@@ -1570,7 +1570,7 @@
     </message>
     <message>
         <source>Last Send</source>
-        <translation>最後の送信</translation>
+        <translation>最終送信</translation>
     </message>
     <message>
         <source>Last Receive</source>
@@ -1582,7 +1582,7 @@
     </message>
     <message>
         <source>The duration of a currently outstanding ping.</source>
-        <translation>現在の異常なpingの間隔</translation>
+        <translation>現在実行中のpingにかかっている時間。</translation>
     </message>
     <message>
         <source>Ping Wait</source>
@@ -1590,27 +1590,27 @@
     </message>
     <message>
         <source>Min Ping</source>
-        <translation>ping最小時間</translation>
+        <translation>最小 Ping</translation>
     </message>
     <message>
         <source>Time Offset</source>
-        <translation>時間オフセット</translation>
+        <translation>タイムオフセット</translation>
     </message>
     <message>
         <source>Last block time</source>
-        <translation>最後のブロック時間</translation>
+        <translation>最終ブロックの日時</translation>
     </message>
     <message>
         <source>&amp;Open</source>
-        <translation>&amp;開く</translation>
+        <translation>開く (&amp;O)</translation>
     </message>
     <message>
         <source>&amp;Console</source>
-        <translation>&amp;コンソール</translation>
+        <translation>コンソール (&amp;C)</translation>
     </message>
     <message>
         <source>&amp;Network Traffic</source>
-        <translation>&amp;ネットワークトラヒック</translation>
+        <translation>ネットワーク (&amp;N)</translation>
     </message>
     <message>
         <source>Totals</source>
@@ -1626,87 +1626,87 @@
     </message>
     <message>
         <source>Debug log file</source>
-        <translation>デバッグログファイル</translation>
+        <translation>デバッグ用ログファイル</translation>
     </message>
     <message>
         <source>Clear console</source>
-        <translation>コンソールのクリア</translation>
+        <translation>コンソールをクリア</translation>
     </message>
     <message>
         <source>1 &amp;hour</source>
-        <translation>1 &amp;時</translation>
+        <translation>1時間 (&amp;H)</translation>
     </message>
     <message>
         <source>1 &amp;day</source>
-        <translation>1 &amp;日</translation>
+        <translation>1日 (&amp;D)</translation>
     </message>
     <message>
         <source>1 &amp;week</source>
-        <translation>1 &amp;週</translation>
+        <translation>1週間 (&amp;W)</translation>
     </message>
     <message>
         <source>1 &amp;year</source>
-        <translation>1 &amp;年</translation>
+        <translation>1年 (&amp;Y)</translation>
     </message>
     <message>
         <source>&amp;Disconnect</source>
-        <translation>&amp;切断</translation>
+        <translation>切断 (&amp;D)</translation>
     </message>
     <message>
         <source>Ban for</source>
-        <translation>禁止の</translation>
+        <translation>Banする:</translation>
     </message>
     <message>
         <source>&amp;Unban</source>
-        <translation>&amp;禁止しない</translation>
+        <translation>Banを解除する (&amp;U)</translation>
     </message>
     <message>
         <source>Welcome to the %1 RPC console.</source>
-        <translation>%1 RPCコンソールへようこそ</translation>
+        <translation>%1 のRPCコンソールへようこそ。</translation>
     </message>
     <message>
         <source>Type &lt;b&gt;help&lt;/b&gt; for an overview of available commands.</source>
-        <translation>&lt;b&gt;help&lt;/b&gt; と入力すると有効なコマンドが表示されます。</translation>
+        <translation>使用可能なコマンドを見るには &lt;b&gt;help&lt;/b&gt; と入力します。</translation>
     </message>
     <message>
         <source>Network activity disabled</source>
-        <translation>無効化されたネットワーク利用</translation>
+        <translation>ネットワーク活動は無効化されました</translation>
     </message>
     <message>
         <source>%1 B</source>
-        <translation>%1 バイト</translation>
+        <translation>%1 B</translation>
     </message>
     <message>
         <source>%1 KB</source>
-        <translation>%1 キロバイト</translation>
+        <translation>%1 KB</translation>
     </message>
     <message>
         <source>%1 MB</source>
-        <translation>%1 メガバイト</translation>
+        <translation>%1 MB</translation>
     </message>
     <message>
         <source>%1 GB</source>
-        <translation>%1 Gギガバイト</translation>
+        <translation>%1 GB</translation>
     </message>
     <message>
         <source>(node id: %1)</source>
-        <translation>(ノードid: %1)</translation>
+        <translation>(ノードID: %1)</translation>
     </message>
     <message>
         <source>via %1</source>
-        <translation> %1経由</translation>
+        <translation>%1経由</translation>
     </message>
     <message>
         <source>never</source>
-        <translation>いままでない</translation>
+        <translation>一度もなし</translation>
     </message>
     <message>
         <source>Inbound</source>
-        <translation>流入</translation>
+        <translation>内向き</translation>
     </message>
     <message>
         <source>Outbound</source>
-        <translation>流出</translation>
+        <translation>外向き</translation>
     </message>
     <message>
         <source>Yes</source>
@@ -1725,43 +1725,43 @@
     <name>ReceiveCoinsDialog</name>
     <message>
         <source>&amp;Amount:</source>
-        <translation>&amp;残高:</translation>
+        <translation>総額:(&amp;A)</translation>
     </message>
     <message>
         <source>&amp;Label:</source>
-        <translation>&amp;ラベル:</translation>
+        <translation>ラベル(&amp;L):</translation>
     </message>
     <message>
         <source>&amp;Message:</source>
-        <translation>&amp;メッセージ:</translation>
+        <translation>メッセージ (&amp;M):</translation>
     </message>
     <message>
         <source>Reuse one of the previously used receiving addresses. Reusing addresses has security and privacy issues. Do not use this unless re-generating a payment request made before.</source>
-        <translation>前回使用された受信アドレスを再利用します。再度アドレスを使用することは、セキュリティとプライバシーの問題になります。再度支払要求を事前に再生成しない限り、これを使用しないようにしてください。</translation>
+        <translation>以前利用した受取用アドレスのどれかを再利用します。アドレスの再利用はセキュリティおよびプライバシーにおいて問題があります。以前作成した支払リクエストを再生成するとき以外は利用しないでください。</translation>
     </message>
     <message>
         <source>R&amp;euse an existing receiving address (not recommended)</source>
-        <translation>&amp;再度存在している受信アドレスを死闘する(非推奨)</translation>
+        <translation>既存の受取用アドレスを再利用する (非推奨) (&amp;E)</translation>
     </message>
     <message>
         <source>An optional message to attach to the payment request, which will be displayed when the request is opened. Note: The message will not be sent with the payment over the Monacoin network.</source>
-        <translation>支払要求に添付されたオプションメッセージは、要求を開いたときに表示されます。メモ: メッセージは、モナーコインネットワーク上で支払と一緒に送信されません。</translation>
+        <translation>支払リクエストが開始された時に表示される、支払リクエストに添える任意のメッセージです。注意：メッセージはMonacoinネットワークを通じて、支払と共に送られるわけではありません。</translation>
     </message>
     <message>
         <source>An optional label to associate with the new receiving address.</source>
-        <translation>新規受信アドレスと関連するオプションラベル</translation>
+        <translation>受取用アドレスに紐づく任意のラベル。</translation>
     </message>
     <message>
         <source>Use this form to request payments. All fields are &lt;b&gt;optional&lt;/b&gt;.</source>
-        <translation>支払要求のための形式を使用してください。すべてのフィールドは&lt;b&gt;おプション&lt;/b&gt; です。</translation>
+        <translation>このフォームを使用して支払のリクエストを行いましょう。すべての項目は&lt;b&gt;任意入力&lt;/b&gt;です。</translation>
     </message>
     <message>
         <source>An optional amount to request. Leave this empty or zero to not request a specific amount.</source>
-        <translation>要求のためのオプション残高。特定の金額の要求をしないときは空か0を入力します。</translation>
+        <translation>リクエストする任意の金額。特定の金額をリクエストするのでない場合には、この欄は空白のままかゼロにしてください。</translation>
     </message>
     <message>
         <source>Clear all fields of the form.</source>
-        <translation>入力形式の全てのフィールドをクリア</translation>
+        <translation>全ての入力項目をクリア</translation>
     </message>
     <message>
         <source>Clear</source>
@@ -1769,15 +1769,15 @@
     </message>
     <message>
         <source>Requested payments history</source>
-        <translation>支払要求履歴</translation>
+        <translation>支払リクエスト履歴</translation>
     </message>
     <message>
         <source>&amp;Request payment</source>
-        <translation>&amp;支払要求</translation>
+        <translation>支払をリクエストする (&amp;R)</translation>
     </message>
     <message>
         <source>Show the selected request (does the same as double clicking an entry)</source>
-        <translation>選択された要求の表示。(空をダブルクリックしたときと同じ)</translation>
+        <translation>選択されたリクエストを表示する（項目をダブルクリックすることでも表示できます）</translation>
     </message>
     <message>
         <source>Show</source>
@@ -1785,7 +1785,7 @@
     </message>
     <message>
         <source>Remove the selected entries from the list</source>
-        <translation>リストから選択されたエントリの削除</translation>
+        <translation>リストから選択項目を削除</translation>
     </message>
     <message>
         <source>Remove</source>
@@ -1793,46 +1793,46 @@
     </message>
     <message>
         <source>Copy URI</source>
-        <translation>コピーURI</translation>
+        <translation>URI をコピーする</translation>
     </message>
     <message>
         <source>Copy label</source>
-        <translation>ラベルのコピー</translation>
+        <translation>ラベルをコピーする</translation>
     </message>
     <message>
         <source>Copy message</source>
-        <translation>メッセージコピー</translation>
+        <translation>メッセージをコピーする</translation>
     </message>
     <message>
         <source>Copy amount</source>
-        <translation>残高のコピー</translation>
+        <translation>総額のコピー</translation>
     </message>
 </context>
 <context>
     <name>ReceiveRequestDialog</name>
     <message>
         <source>QR Code</source>
-        <translation>QRコード</translation>
+        <translation>QR コード</translation>
     </message>
     <message>
         <source>Copy &amp;URI</source>
-        <translation>&amp;URIコピー</translation>
+        <translation>URI をコピーする (&amp;U)</translation>
     </message>
     <message>
         <source>Copy &amp;Address</source>
-        <translation>&amp;アドレスコピー</translation>
+        <translation>アドレスをコピーする (&amp;A)</translation>
     </message>
     <message>
         <source>&amp;Save Image...</source>
-        <translation>&amp;イメージ保存...</translation>
+        <translation>画像を保存(&amp;S)</translation>
     </message>
     <message>
         <source>Request payment to %1</source>
-        <translation>%1のための支払要求</translation>
+        <translation>%1 への支払いリクエストを行う</translation>
     </message>
     <message>
         <source>Payment information</source>
-        <translation>支払情報</translation>
+        <translation>支払い情報</translation>
     </message>
     <message>
         <source>URI</source>
@@ -1844,7 +1844,7 @@
     </message>
     <message>
         <source>Amount</source>
-        <translation>残高</translation>
+        <translation>総額</translation>
     </message>
     <message>
         <source>Label</source>
@@ -1856,11 +1856,11 @@
     </message>
     <message>
         <source>Resulting URI too long, try to reduce the text for label / message.</source>
-        <translation>URIが長すぎるので、ラベルまたはメッセージを短くしてください。</translation>
+        <translation>URI が長くなり過ぎます。ラベルやメッセージのテキストを短くしてください。</translation>
     </message>
     <message>
         <source>Error encoding URI into QR Code.</source>
-        <translation>QRコードのURIのコード化エラー</translation>
+        <translation>QR コード用の URI エンコードでエラー。</translation>
     </message>
 </context>
 <context>
@@ -1879,7 +1879,7 @@
     </message>
     <message>
         <source>(no label)</source>
-        <translation>(ラベルなし)</translation>
+        <translation>（ラベル無し）</translation>
     </message>
     <message>
         <source>(no message)</source>
@@ -1887,22 +1887,22 @@
     </message>
     <message>
         <source>(no amount requested)</source>
-        <translation>(料金要求なし)</translation>
+        <translation>(金額指定なし)</translation>
     </message>
     <message>
         <source>Requested</source>
-        <translation>要求済み</translation>
+        <translation>要求</translation>
     </message>
 </context>
 <context>
     <name>SendCoinsDialog</name>
     <message>
         <source>Send Coins</source>
-        <translation>コイン送付</translation>
+        <translation>コインを送る</translation>
     </message>
     <message>
         <source>Coin Control Features</source>
-        <translation>コイン制御機能</translation>
+        <translation>コインコントロール機能</translation>
     </message>
     <message>
         <source>Inputs...</source>
@@ -1910,15 +1910,15 @@
     </message>
     <message>
         <source>automatically selected</source>
-        <translation>自動的に選択される</translation>
+        <translation>自動選択</translation>
     </message>
     <message>
         <source>Insufficient funds!</source>
-        <translation>残高不十分!</translation>
+        <translation>残高不足です！</translation>
     </message>
     <message>
         <source>Quantity:</source>
-        <translation>量:</translation>
+        <translation>数量:</translation>
     </message>
     <message>
         <source>Bytes:</source>
@@ -1926,7 +1926,7 @@
     </message>
     <message>
         <source>Amount:</source>
-        <translation>残高:</translation>
+        <translation>総額:</translation>
     </message>
     <message>
         <source>Fee:</source>
@@ -1934,39 +1934,39 @@
     </message>
     <message>
         <source>After Fee:</source>
-        <translation>後の料金:</translation>
+        <translation>手数料差引後:</translation>
     </message>
     <message>
         <source>Change:</source>
-        <translation>変更:</translation>
+        <translation>釣り銭:</translation>
     </message>
     <message>
         <source>If this is activated, but the change address is empty or invalid, change will be sent to a newly generated address.</source>
-        <translation>これが有効化されていて変更アドレスが空または無効でない時、変更は新しく生成されたアドレスへ送信されます。</translation>
+        <translation>これが有効にもかかわらずおつりアドレスが空欄であったり無効であった場合には、おつりは新しく生成されたアドレスへ送金されます。</translation>
     </message>
     <message>
         <source>Custom change address</source>
-        <translation>カスタム変更アドレス</translation>
+        <translation>カスタムおつりアドレス</translation>
     </message>
     <message>
         <source>Transaction Fee:</source>
-        <translation>処理費用:</translation>
+        <translation>トランザクション手数料：</translation>
     </message>
     <message>
         <source>Choose...</source>
-        <translation>選択...</translation>
+        <translation>選択……</translation>
     </message>
     <message>
         <source>collapse fee-settings</source>
-        <translation>料金設定を折りたたむ</translation>
+        <translation>手数料設定を折りたたむ</translation>
     </message>
     <message>
         <source>per kilobyte</source>
-        <translation>キロバイトごと</translation>
+        <translation>1キロバイトあたり手数料</translation>
     </message>
     <message>
         <source>If the custom fee is set to 1000 satoshis and the transaction is only 250 bytes, then "per kilobyte" only pays 250 satoshis in fee, while "total at least" pays 1000 satoshis. For transactions bigger than a kilobyte both pay by kilobyte.</source>
-        <translation>カスタム料金が1000 satoshiで処理が250バイトのみの場合、料金はキロバイトあたりは250 satoshiのみとなり、最新の合計は1000 satoshiまで支払います。処理が1キロバイトよりも大きい場合、キロバイトごとに支払いが行われます。</translation>
+        <translation>カスタム手数料が1000satoshiに設定されている場合、トランザクションサイズが250バイトとすると、「1キロバイトあたり手数料」では250satoshiの手数料のみを支払いますが、「最小手数料」では1000satoshiを支払います。1キロバイトを超えるトランザクションの場合には、どちらの方法を選択したとしても1キロバイトあたりで支払われます。</translation>
     </message>
     <message>
         <source>Hide</source>
@@ -1974,11 +1974,11 @@
     </message>
     <message>
         <source>Paying only the minimum fee is just fine as long as there is less transaction volume than space in the blocks. But be aware that this can end up in a never confirming transaction once there is more demand for monacoin transactions than the network can process.</source>
-        <translation>最小の料金のみ支払いは、ブロック内の処理容量よりも小さい場合に限り、問題ありません。しかし、ネットワークの処理できる量よりも、モナーコイン処理のほうが需要があり、最終的にその確認処理が実行されないことに注意する必要があります。</translation>
+        <translation>ブロックの容量に比べてトランザクション流量が少ないうちは最小手数料のみの支払で十分です。しかしながらネットワークが処理しきれないほどmonacoinトランザクションの需要がひとたび生まれてしまった場合には、永遠に検証がされないトランザクションになってしまう可能性があることに注意してください。</translation>
     </message>
     <message>
         <source>(read the tooltip)</source>
-        <translation>(ツールチップを読む)</translation>
+        <translation>（ツールチップをお読みください）</translation>
     </message>
     <message>
         <source>Recommended:</source>
@@ -1990,31 +1990,31 @@
     </message>
     <message>
         <source>(Smart fee not initialized yet. This usually takes a few blocks...)</source>
-        <translation>(スマート料金は初期化されていません。通常であれば数ブロックかかります...)</translation>
+        <translation>（スマート手数料はまだ初期化されていません。これにはおおよそ数ブロックほどかかります……）</translation>
     </message>
     <message>
         <source>Send to multiple recipients at once</source>
-        <translation>一度に複数の受信者に送信します</translation>
+        <translation>一度に複数の人に送る</translation>
     </message>
     <message>
         <source>Add &amp;Recipient</source>
-        <translation>追加&amp;受信者</translation>
+        <translation>受取人を追加 (&amp;R)</translation>
     </message>
     <message>
         <source>Clear all fields of the form.</source>
-        <translation>入力形式の全てのフィールドをクリア</translation>
+        <translation>全ての入力項目をクリア</translation>
     </message>
     <message>
         <source>Dust:</source>
-        <translation>ごみ:</translation>
+        <translation>ダスト：</translation>
     </message>
     <message>
         <source>Confirmation time target:</source>
-        <translation>目標時間の確認:</translation>
+        <translation>検証時間のターゲット:</translation>
     </message>
     <message>
         <source>Clear &amp;All</source>
-        <translation>クリア&amp;全て</translation>
+        <translation>すべてクリア (&amp;A)</translation>
     </message>
     <message>
         <source>Balance:</source>
@@ -2022,27 +2022,27 @@
     </message>
     <message>
         <source>Confirm the send action</source>
-        <translation>送信実行の確認</translation>
+        <translation>送る操作を確認する</translation>
     </message>
     <message>
         <source>S&amp;end</source>
-        <translation>&amp;送信</translation>
+        <translation>送金 (&amp;E)</translation>
     </message>
     <message>
         <source>Copy quantity</source>
-        <translation>量をコピー</translation>
+        <translation>数量をコピーする</translation>
     </message>
     <message>
         <source>Copy amount</source>
-        <translation>残高のコピー</translation>
+        <translation>総額のコピーする</translation>
     </message>
     <message>
         <source>Copy fee</source>
-        <translation>料金をコピー</translation>
+        <translation>手数料をコピーする</translation>
     </message>
     <message>
         <source>Copy after fee</source>
-        <translation>後料金をこぴー</translation>
+        <translation>手数料差引後の値をコピーする</translation>
     </message>
     <message>
         <source>Copy bytes</source>
@@ -2050,114 +2050,114 @@
     </message>
     <message>
         <source>Copy dust</source>
-        <translation>ゴミをコピー</translation>
+        <translation>ダストをコピーする</translation>
     </message>
     <message>
         <source>Copy change</source>
-        <translation>変更をコピー</translation>
+        <translation>釣り銭をコピーする</translation>
     </message>
     <message>
         <source>%1 to %2</source>
-        <translation>%2から%1</translation>
+        <translation>%1 から %2</translation>
     </message>
     <message>
         <source>Are you sure you want to send?</source>
-        <translation>送信してもよろしいですか？</translation>
+        <translation>送ってよろしいですか？</translation>
     </message>
     <message>
         <source>added as transaction fee</source>
-        <translation>処理料金として追加済み</translation>
+        <translation>取引手数料として追加された</translation>
     </message>
     <message>
         <source>Total Amount %1</source>
-        <translation>合計残高: %1</translation>
+        <translation>合計：　%1</translation>
     </message>
     <message>
         <source>or</source>
-        <translation>もしくは</translation>
+        <translation>または</translation>
     </message>
     <message>
         <source>Confirm send coins</source>
-        <translation>送信コイン確認</translation>
+        <translation>コインを送る確認</translation>
     </message>
     <message>
         <source>The recipient address is not valid. Please recheck.</source>
-        <translation>受信者アドレスは無効です。再度確認してください。</translation>
+        <translation>受取アドレスが不正です。再チェックしてください。</translation>
     </message>
     <message>
         <source>The amount to pay must be larger than 0.</source>
-        <translation>支払料金は0より大きい必要があります。</translation>
+        <translation>支払額は0より大きくないといけません。</translation>
     </message>
     <message>
         <source>The amount exceeds your balance.</source>
-        <translation>料金が残高を超えています。</translation>
+        <translation>額が残高を超えています。</translation>
     </message>
     <message>
         <source>The total exceeds your balance when the %1 transaction fee is included.</source>
-        <translation>%1の処理料金を含めると、合計が残高を超えます。</translation>
+        <translation>%1 の取引手数料を含めると額が残高を超えています。</translation>
     </message>
     <message>
         <source>Duplicate address found: addresses should only be used once each.</source>
-        <translation>重複アドレスの発見: アドレスはそれぞれ一つずつ使用される必要があります。</translation>
+        <translation>重複したアドレスが見つかりました: アドレスはそれぞれ一度のみ使用することができます。</translation>
     </message>
     <message>
         <source>Transaction creation failed!</source>
-        <translation>処理の作成に失敗しました!</translation>
+        <translation>トラザクションの作成に失敗しました!</translation>
     </message>
     <message>
         <source>The transaction was rejected with the following reason: %1</source>
-        <translation>処理は次の理由により却下されました: %1</translation>
+        <translation>トランザクションは以下の理由により拒絶されました: %1</translation>
     </message>
     <message>
         <source>A fee higher than %1 is considered an absurdly high fee.</source>
-        <translation>料金が%1より高い場合、非常識に高い料金として考えられます。</translation>
+        <translation>%1 よりも高い手数料の場合、手数料が高すぎると判断されます。</translation>
     </message>
     <message>
         <source>Payment request expired.</source>
-        <translation>支払要求期限切れ</translation>
+        <translation>支払いリクエストの期限が切れました。</translation>
     </message>
     <message>
         <source>Pay only the required fee of %1</source>
-        <translation>%1の必須料金のみ支払う</translation>
+        <translation>要求手数料 %1 のみを支払う</translation>
     </message>
     <message>
         <source>Warning: Invalid Monacoin address</source>
-        <translation>注意: 無効なモナーコインアドレス</translation>
+        <translation>警告：無効なMonacoinアドレスです</translation>
     </message>
     <message>
         <source>Warning: Unknown change address</source>
-        <translation>注意: 未知の変更アドレス</translation>
+        <translation>警告：未知のおつりアドレスです</translation>
     </message>
     <message>
         <source>Confirm custom change address</source>
-        <translation>カスタム変更アドレスの確認</translation>
+        <translation>カスタムおつりアドレスを確認</translation>
     </message>
     <message>
         <source>The address you selected for change is not part of this wallet. Any or all funds in your wallet may be sent to this address. Are you sure?</source>
-        <translation>変更のために選択したアドレスは、ウォレットの一部ではありません。ウォレット内の一部またはすべて料金はこのアドレスで送付される必要があります。実行してもよろしいでしょうか？</translation>
+        <translation>おつりとして指定されたアドレスはこのウォレットに属さないもののようです。このウォレットの一部またはすべての資産がこのアドレスへ送金されます。よろしいですか？</translation>
     </message>
     <message>
         <source>(no label)</source>
-        <translation>(ラベルなし)</translation>
+        <translation>（ラベル無し）</translation>
     </message>
 </context>
 <context>
     <name>SendCoinsEntry</name>
     <message>
         <source>A&amp;mount:</source>
-        <translation>&amp;残高:</translation>
+        <translation>金額(&amp;A):</translation>
     </message>
     <message>
         <source>Pay &amp;To:</source>
-        <translation>支払&amp;宛先:</translation>
+        <translation>送り先(&amp;T):</translation>
     </message>
     <message>
         <source>&amp;Label:</source>
-        <translation>&amp;ラベル:</translation>
+        <translation>ラベル(&amp;L):</translation>
     </message>
     <message>
         <source>Choose previously used address</source>
-        <translation>前回使用したアドレスの選択</translation>
+        <translation>前に使用したアドレスを選ぶ</translation>
     </message>
     <message>
         <source>This is a normal payment.</source>
@@ -2165,7 +2165,7 @@
     </message>
     <message>
         <source>The Monacoin address to send the payment to</source>
-        <translation>支払に送信するモナーコインアドレス</translation>
+        <translation>支払の送金先Monacoinアドレス</translation>
     </message>
     <message>
         <source>Alt+A</source>
@@ -2173,7 +2173,7 @@
     </message>
     <message>
         <source>Paste address from clipboard</source>
-        <translation>クリップボードからアドレスを貼り付ける</translation>
+        <translation>クリップボードからアドレスを貼付ける</translation>
     </message>
     <message>
         <source>Alt+P</source>
@@ -2181,15 +2181,15 @@
     </message>
     <message>
         <source>Remove this entry</source>
-        <translation>入力の削除</translation>
+        <translation>この項目を削除する</translation>
     </message>
     <message>
         <source>The fee will be deducted from the amount being sent. The recipient will receive less monacoins than you enter in the amount field. If multiple recipients are selected, the fee is split equally.</source>
-        <translation>料金は送信料金から控除されます。受信者は入力された料金よりも低い金額を受け取ります。複数の受信者を選択した場合、この料金は同額に分けられます。</translation>
+        <translation>送金する金額から手数料が差し引かれます。受取人は数量フィールドで指定した量よりも少ないモナーコインを受け取ります。受取人が複数いる場合には、手数料は均等割されます。</translation>
     </message>
     <message>
         <source>S&amp;ubtract fee from amount</source>
-        <translation>&amp;残高から料金を差し引く</translation>
+        <translation>送金額から手数料を差し引く (&amp;U)</translation>
     </message>
     <message>
         <source>Message:</source>
@@ -2197,19 +2197,19 @@
     </message>
     <message>
         <source>This is an unauthenticated payment request.</source>
-        <translation>これは未証明の支払要求です。</translation>
+        <translation>これは未認証の支払いリクエストです。</translation>
     </message>
     <message>
         <source>This is an authenticated payment request.</source>
-        <translation>これは証明済みの支払要求です。</translation>
+        <translation>これは認証済みの支払いリクエストです。</translation>
     </message>
     <message>
         <source>Enter a label for this address to add it to the list of used addresses</source>
-        <translation>使用されたアドレス一覧のために、このアドレスのラベルを入力します。</translation>
+        <translation>このアドレスに対するラベルを入力することで、使用済みアドレスの一覧に追加することができます</translation>
     </message>
     <message>
         <source>A message that was attached to the monacoin: URI which will be stored with the transaction for your reference. Note: This message will not be sent over the Monacoin network.</source>
-        <translation>参考資料に保存された処理のモナーコインURIは、メッセージに添付されます。メモ: このメッセージはモナーコイン上で送信されません。</translation>
+        <translation>monacoin: URIに添付されていたメッセージです。これは参照用としてトランザクションとともに保存されます。注意：このメッセージはMonacoinネットワークを通して送信されるわけではありません。</translation>
     </message>
     <message>
         <source>Pay To:</source>
@@ -2221,7 +2221,7 @@
     </message>
     <message>
         <source>Enter a label for this address to add it to your address book</source>
-        <translation>アドレス帳にアドレスを追加すためのラベルの入力</translation>
+        <translation>アドレス帳に追加するには、このアドレスのラベルを入力します</translation>
     </message>
 </context>
 <context>
@@ -2235,34 +2235,34 @@
     <name>ShutdownWindow</name>
     <message>
         <source>%1 is shutting down...</source>
-        <translation>%1は停止中です...</translation>
+        <translation>%1 をシャットダウンしています...</translation>
     </message>
     <message>
         <source>Do not shut down the computer until this window disappears.</source>
-        <translation>この画面が消えるまで、コンピュータを停止しないでください。</translation>
+        <translation>このウィンドウが消えるまでコンピュータをシャットダウンしないで下さい。</translation>
     </message>
 </context>
 <context>
     <name>SignVerifyMessageDialog</name>
     <message>
         <source>Signatures - Sign / Verify a Message</source>
-        <translation>署名 - サイン / メッセージの確認</translation>
+        <translation>署名 - メッセージの署名/検証</translation>
     </message>
     <message>
         <source>&amp;Sign Message</source>
-        <translation>&amp;署名メッセージ</translation>
+        <translation>メッセージの署名 (&amp;S)</translation>
     </message>
     <message>
         <source>You can sign messages/agreements with your addresses to prove you can receive monacoins sent to them. Be careful not to sign anything vague or random, as phishing attacks may try to trick you into signing your identity over to them. Only sign fully-detailed statements you agree to.</source>
-        <translation>送信されたモナーコインを受信できることを証明するために、アドレスのメッセージや同意事項に署名できます。フィッシング攻撃が署名を利用する可能性があるので、署名が曖昧やランダムでないことに注意してください。詳細な明細のみに署名されます。</translation>
+        <translation>あなたの所有しているアドレスによりメッセージや合意書に署名をすることで、それらアドレスに対して送られたモナーコインを受け取ることができることを証明できます。フィッシング攻撃により不正にあなたの識別情報を署名させられてしまうことを防ぐために、不明確なものやランダムなものに対して署名しないよう注意してください。合意することが可能な、よく詳細の記された文言にのみ署名するようにしてください。</translation>
     </message>
     <message>
         <source>The Monacoin address to sign the message with</source>
-        <translation>メッセージ署名するためのモナーコインアドレス</translation>
+        <translation>メッセージを署名するMonacoinアドレス</translation>
     </message>
     <message>
         <source>Choose previously used address</source>
-        <translation>前回使用したアドレスの選択</translation>
+        <translation>前に使用したアドレスを選ぶ</translation>
     </message>
     <message>
         <source>Alt+A</source>
@@ -2270,7 +2270,7 @@
     </message>
     <message>
         <source>Paste address from clipboard</source>
-        <translation>クリップボードからアドレスを貼り付ける</translation>
+        <translation>クリップボードからアドレスを貼付ける</translation>
     </message>
     <message>
         <source>Alt+P</source>
@@ -2278,7 +2278,7 @@
     </message>
     <message>
         <source>Enter the message you want to sign here</source>
-        <translation>ここに署名をするメッセージを入力</translation>
+        <translation>ここにあなたが署名するメッセージを入力します</translation>
     </message>
     <message>
         <source>Signature</source>
@@ -2286,75 +2286,75 @@
     </message>
     <message>
         <source>Copy the current signature to the system clipboard</source>
-        <translation>システムのクリップボードへ現在の署名をコピー</translation>
+        <translation>現在の署名をシステムのクリップボードにコピーする</translation>
     </message>
     <message>
         <source>Sign the message to prove you own this Monacoin address</source>
-        <translation>モナーコインアドレスを証明するために、メッセージに署名</translation>
+        <translation>この Monacoin アドレスを所有していることを証明するためにメッセージに署名</translation>
     </message>
     <message>
         <source>Sign &amp;Message</source>
-        <translation>署名&amp;メッセージ</translation>
+        <translation>メッセージの署名 (&amp;M)</translation>
     </message>
     <message>
         <source>Reset all sign message fields</source>
-        <translation>全ての署名フィールドをリセット</translation>
+        <translation>入力項目の内容をすべて消去します</translation>
     </message>
     <message>
         <source>Clear &amp;All</source>
-        <translation>クリア&amp;全て</translation>
+        <translation>すべてクリア (&amp;A)</translation>
     </message>
     <message>
         <source>&amp;Verify Message</source>
-        <translation>&amp;メッセージ確認</translation>
+        <translation>メッセージの検証 (&amp;V)</translation>
     </message>
     <message>
         <source>Enter the receiver's address, message (ensure you copy line breaks, spaces, tabs, etc. exactly) and signature below to verify the message. Be careful not to read more into the signature than what is in the signed message itself, to avoid being tricked by a man-in-the-middle attack. Note that this only proves the signing party receives with the address, it cannot prove sendership of any transaction!</source>
-        <translation>以下のメッセージを確認して、受信者のアドレス、メッセージ（タブやすスペースなどを正確にこぴーしてください）、署名を入力してください。中間の攻撃者からのアタックを避けるために、署名されていないメッセージを読まないように注意してください。署名はアドレスと受信を証明することはできますが、送信者の処理を証明できないことに注意してください。</translation>
+        <translation>受取人のアドレスとメッセージ（改行やスペース、タブなども完全に一致するよう注意してください）および署名を以下に入力し、メッセージの署名を検証してください。中間者攻撃により騙されるのを防ぐため、署名対象のメッセージに書かれていること以上の意味を署名から読み取ろうとしないよう注意してください。これは署名作成者がこのアドレスで受け取ったことを証明するだけであり、トランザクションの送信権限を証明するものではないことに注意してください！</translation>
     </message>
     <message>
         <source>The Monacoin address the message was signed with</source>
-        <translation>メッセージのモナーコインアドレスはサインされています</translation>
+        <translation>メッセージの署名に使われたMonacoinアドレス</translation>
     </message>
     <message>
         <source>Verify the message to ensure it was signed with the specified Monacoin address</source>
-        <translation>特定のモナーコインアドレスと署名されているメッセージであることを確認してください。</translation>
+        <translation>指定された Monacoin アドレスで署名されたことを保証するメッセージを検証</translation>
     </message>
     <message>
         <source>Verify &amp;Message</source>
-        <translation>確認&amp;メッセージ</translation>
+        <translation>メッセージの検証 (&amp;M)</translation>
     </message>
     <message>
         <source>Reset all verify message fields</source>
-        <translation>全ての確認フィールドをリセット</translation>
+        <translation>入力項目の内容をすべて消去します</translation>
     </message>
     <message>
         <source>Click "Sign Message" to generate signature</source>
-        <translation>署名を生成するため、"署名メッセージ"をクリック</translation>
+        <translation>署名を作成するには"メッセージの署名"をクリック</translation>
     </message>
     <message>
         <source>The entered address is invalid.</source>
-        <translation>入力されたアドレスは無効です。</translation>
+        <translation>不正なアドレスが入力されました。</translation>
     </message>
     <message>
         <source>Please check the address and try again.</source>
-        <translation>アドレスを確認して、再実行してください。</translation>
+        <translation>アドレスを確かめてからもう一度試してください。</translation>
     </message>
     <message>
         <source>The entered address does not refer to a key.</source>
-        <translation>入力されたアドレスは鍵と関連がありません。</translation>
+        <translation>入力されたアドレスに関連するキーがありません。</translation>
     </message>
     <message>
         <source>Wallet unlock was cancelled.</source>
-        <translation>ウォレットのロック解除は中断されました。</translation>
+        <translation>ウォレットのアンロックはキャンセルされました。</translation>
     </message>
     <message>
         <source>Private key for the entered address is not available.</source>
-        <translation>入力されたプライベートキーは無効です。</translation>
+        <translation>入力されたアドレスのプライベート キーが無効です。</translation>
     </message>
     <message>
         <source>Message signing failed.</source>
-        <translation>メッセージの署名は失敗しました。</translation>
+        <translation>メッセージの署名に失敗しました。</translation>
     </message>
     <message>
         <source>Message signed.</source>
@@ -2362,23 +2362,23 @@
     </message>
     <message>
         <source>The signature could not be decoded.</source>
-        <translation>署名は復号化できませんでした。</translation>
+        <translation>署名がデコードできません。</translation>
     </message>
     <message>
         <source>Please check the signature and try again.</source>
-        <translation>署名を確認して、再実行してください。</translation>
+        <translation>署名を確認してからもう一度試してください。</translation>
     </message>
     <message>
         <source>The signature did not match the message digest.</source>
-        <translation>署名は、メッセージダイジェストと一致しませんでした。</translation>
+        <translation>署名はメッセージ ダイジェストと一致しませんでした。</translation>
     </message>
     <message>
         <source>Message verification failed.</source>
-        <translation>メッセージ確認は失敗しました。</translation>
+        <translation>メッセージの検証に失敗しました。</translation>
     </message>
     <message>
         <source>Message verified.</source>
-        <translation>メッセージは確認されました。</translation>
+        <translation>メッセージは検証されました。</translation>
     </message>
 </context>
 <context>
@@ -2392,18 +2392,18 @@
     <name>TrafficGraphWidget</name>
     <message>
         <source>KB/s</source>
-        <translation>キロバイト/秒</translation>
+        <translation>KB/s</translation>
     </message>
 </context>
 <context>
     <name>TransactionDesc</name>
     <message>
         <source>Open until %1</source>
-        <translation>%1まで開く</translation>
+        <translation>ユニット %1 を開く</translation>
     </message>
     <message>
         <source>conflicted with a transaction with %1 confirmations</source>
-        <translation>処理と%1確認が矛盾しています。</translation>
+        <translation>%1 検証のトランザクションと衝突</translation>
     </message>
     <message>
         <source>%1/offline</source>
@@ -2411,11 +2411,11 @@
     </message>
     <message>
         <source>0/unconfirmed, %1</source>
-        <translation>0/未確認, %1</translation>
+        <translation>0/未検証, %1</translation>
     </message>
     <message>
         <source>in memory pool</source>
-        <translation>メモリプール中</translation>
+        <translation>メモリプール内</translation>
     </message>
     <message>
         <source>not in memory pool</source>
@@ -2423,11 +2423,11 @@
     </message>
     <message>
         <source>abandoned</source>
-        <translation>放棄</translation>
+        <translation>中止</translation>
     </message>
     <message>
         <source>%1/unconfirmed</source>
-        <translation>%1/未確認</translation>
+        <translation>%1/未検証</translation>
     </message>
     <message>
         <source>%1 confirmations</source>
@@ -2435,11 +2435,11 @@
     </message>
     <message>
         <source>Status</source>
-        <translation>状態</translation>
+        <translation>ステータス</translation>
     </message>
     <message>
         <source>, has not been successfully broadcast yet</source>
-        <translation>まだ、散布に成功していません</translation>
+        <translation>まだブロードキャストが成功していません</translation>
     </message>
     <message>
         <source>Date</source>
@@ -2451,27 +2451,27 @@
     </message>
     <message>
         <source>Generated</source>
-        <translation>生成済み</translation>
+        <translation>生成された</translation>
     </message>
     <message>
         <source>From</source>
-        <translation>送信元</translation>
+        <translation>送信</translation>
     </message>
     <message>
         <source>unknown</source>
-        <translation>不明</translation>
+        <translation>未確認</translation>
     </message>
     <message>
         <source>To</source>
-        <translation>送信先</translation>
+        <translation>受信</translation>
     </message>
     <message>
         <source>own address</source>
-        <translation>自アドレス</translation>
+        <translation>自分のアドレス</translation>
     </message>
     <message>
         <source>watch-only</source>
-        <translation>読み取り専用</translation>
+        <translation>監視限定</translation>
     </message>
     <message>
         <source>label</source>
@@ -2479,31 +2479,31 @@
     </message>
     <message>
         <source>Credit</source>
-        <translation>信用</translation>
+        <translation>クレジット</translation>
     </message>
     <message>
         <source>not accepted</source>
-        <translation>承認拒否</translation>
+        <translation>承認されなかった</translation>
     </message>
     <message>
         <source>Debit</source>
-        <translation>デビット</translation>
+        <translation>引き落とし額</translation>
     </message>
     <message>
         <source>Total debit</source>
-        <translation>デビットの合計</translation>
+        <translation>総出金額</translation>
     </message>
     <message>
         <source>Total credit</source>
-        <translation>合計クレジット</translation>
+        <translation>総入金額</translation>
     </message>
     <message>
         <source>Transaction fee</source>
-        <translation>処理料金</translation>
+        <translation>取引手数料</translation>
     </message>
     <message>
         <source>Net amount</source>
-        <translation>ネット残高</translation>
+        <translation>正味金額</translation>
     </message>
     <message>
         <source>Message</source>
@@ -2515,11 +2515,11 @@
     </message>
     <message>
         <source>Transaction ID</source>
-        <translation>処理ID</translation>
+        <translation>取引 ID</translation>
     </message>
     <message>
         <source>Transaction total size</source>
-        <translation>処理合計サイズ</translation>
+        <translation>トランザクションの全体サイズ</translation>
     </message>
     <message>
         <source>Output index</source>
@@ -2531,7 +2531,7 @@
     </message>
     <message>
         <source>Amount</source>
-        <translation>残高</translation>
+        <translation>総額</translation>
     </message>
     </context>
 <context>
@@ -2549,15 +2549,15 @@
     </message>
     <message>
         <source>Open until %1</source>
-        <translation>%1まで開く</translation>
+        <translation>ユニット %1 を開く</translation>
     </message>
     <message>
         <source>watch-only</source>
-        <translation>読み取り専用</translation>
+        <translation>監視限定</translation>
     </message>
     <message>
         <source>(no label)</source>
-        <translation>(ラベルなし)</translation>
+        <translation>（ラベル無し）</translation>
     </message>
     </context>
 <context>
@@ -2576,15 +2576,15 @@
     </message>
     <message>
         <source>Copy transaction ID</source>
-        <translation>トランザクションIDのコピー</translation>
+        <translation>アドレスをコピーする</translation>
     </message>
     <message>
         <source>Comma separated file (*.csv)</source>
-        <translation>カンマ区切りのファイル(*.csv)</translation>
+        <translation>テキスト CSV (*.csv)</translation>
     </message>
     <message>
         <source>Confirmed</source>
-        <translation>確認済み</translation>
+        <translation>検証済み</translation>
     </message>
     <message>
         <source>Date</source>
@@ -2600,7 +2600,7 @@
     </message>
     <message>
         <source>Exporting Failed</source>
-        <translation>出力の失敗</translation>
+        <translation>エクスポートに失敗しました</translation>
     </message>
     </context>
 <context>
@@ -2613,18 +2613,18 @@
     <name>WalletModel</name>
     <message>
         <source>Send Coins</source>
-        <translation>コイン送付</translation>
+        <translation>コインを送る</translation>
     </message>
 </context>
 <context>
     <name>WalletView</name>
     <message>
         <source>&amp;Export</source>
-        <translation>&amp;出力</translation>
+        <translation>エクスポート (&amp;E)</translation>
     </message>
     <message>
         <source>Export the data in the current tab to a file</source>
-        <translation>ファイルの現在のタブを出力します</translation>
+        <translation>ファイルに現在のタブのデータをエクスポート</translation>
     </message>
     </context>
 <context>

--- a/src/qt/locale/bitcoin_ja_JP.ts
+++ b/src/qt/locale/bitcoin_ja_JP.ts
@@ -624,7 +624,7 @@
     </message>
     <message>
         <source>Copy amount</source>
-        <translation>総額のコピー</translation>
+        <translation>総額をコピーする</translation>
     </message>
     <message>
         <source>Copy transaction ID</source>
@@ -660,7 +660,7 @@
     </message>
     <message>
         <source>Copy change</source>
-        <translation>釣り銭をコピー</translation>
+        <translation>釣り銭をコピーする</translation>
     </message>
     <message>
         <source>(%1 locked)</source>
@@ -1805,7 +1805,7 @@
     </message>
     <message>
         <source>Copy amount</source>
-        <translation>総額のコピー</translation>
+        <translation>総額をコピーする</translation>
     </message>
 </context>
 <context>
@@ -2034,7 +2034,7 @@
     </message>
     <message>
         <source>Copy amount</source>
-        <translation>総額のコピーする</translation>
+        <translation>総額をコピーする</translation>
     </message>
     <message>
         <source>Copy fee</source>


### PR DESCRIPTION
I fix japanese translation.

"おプション"とかを修正しました。
基本的には"bitcoin_ja.ts"に合わせましたが、
同じページ内で表記ゆれがあるのもついでに修正してます。