### PR TITLE
[Trivial] Fix a misspelled variable name: Digisheld >> Digishield

### DIFF
--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -84,7 +84,7 @@ public:
         consensus.powLimit = uint256S("00000fffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"); 
         consensus.nPowTargetTimespan = 1.1 * 24 * 60 * 60; // 1.1 days
         consensus.nPowTargetSpacing = 1.5 * 60; // 1.5 minutes
-        consensus.nPowTargetTimespanDigisheld = 1.5 * 60;
+        consensus.nPowTargetTimespanDigishield = 1.5 * 60;
         consensus.fPowAllowMinDifficultyBlocks = false;
         consensus.fPowNoRetargeting = false;
         consensus.nRuleChangeActivationThreshold = 7560; // 75% of 10080
@@ -196,7 +196,7 @@ public:
         consensus.powLimit = uint256S("00000fffffffffffffffffffffffffffffffffffffffffffffffffffffffffff");
         consensus.nPowTargetTimespan = 1.1 * 24 * 60 * 60; // 1.1 days
         consensus.nPowTargetSpacing = 1.5 * 60; // 1.5 minutes
-        consensus.nPowTargetTimespanDigisheld = 1.5 * 60;
+        consensus.nPowTargetTimespanDigishield = 1.5 * 60;
         consensus.fPowAllowMinDifficultyBlocks = true;
         consensus.fPowNoRetargeting = false;
         consensus.nRuleChangeActivationThreshold = 75; // 75% for testchains
@@ -295,7 +295,7 @@ public:
         consensus.powLimit = uint256S("7fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff");
         consensus.nPowTargetTimespan = 1.1 * 24 * 60 * 60; // 1.5 days
         consensus.nPowTargetSpacing = 1.5 * 60; // 1.5 minutes
-        consensus.nPowTargetTimespanDigisheld = 1.5 * 60;
+        consensus.nPowTargetTimespanDigishield = 1.5 * 60;
         consensus.fPowAllowMinDifficultyBlocks = true;
         consensus.fPowNoRetargeting = true;
         consensus.nRuleChangeActivationThreshold = 108; // 75% for testchains

--- a/src/consensus/params.h
+++ b/src/consensus/params.h
@@ -72,9 +72,9 @@ struct Params {
     bool fPowNoRetargeting;
     int64_t nPowTargetSpacing;
     int64_t nPowTargetTimespan;
-    int64_t nPowTargetTimespanDigisheld;
+    int64_t nPowTargetTimespanDigishield;
     int64_t DifficultyAdjustmentInterval() const { return nPowTargetTimespan / nPowTargetSpacing; }
-    int64_t DifficultyAdjustmentIntervalDigisheld() const { return nPowTargetTimespanDigisheld / nPowTargetSpacing; }
+    int64_t DifficultyAdjustmentIntervalDigishield() const { return nPowTargetTimespanDigishield / nPowTargetSpacing; }
     uint256 nMinimumChainWork;
     uint256 defaultAssumeValid;
 };

--- a/src/pow.cpp
+++ b/src/pow.cpp
@@ -173,7 +173,7 @@ unsigned int GetNextWorkRequired(const CBlockIndex* pindexLast, const CBlockHead
 
     int64_t adjustmentInterval = params.DifficultyAdjustmentInterval();
     if ((pindexLast->nHeight+1) >= Params().SwitchDIGIblock()) {
-        adjustmentInterval = params.DifficultyAdjustmentIntervalDigisheld();
+        adjustmentInterval = params.DifficultyAdjustmentIntervalDigishield();
     }
 
     // Only change once per difficulty adjustment interval
@@ -223,7 +223,7 @@ unsigned int CalculateNextWorkRequired(const CBlockIndex* pindexLast, int64_t nF
     bool fNewDifficultyProtocol = ((pindexLast->nHeight+1) >= Params().SwitchDIGIblock());
     int64_t targetTimespan =  params.nPowTargetTimespan;
     if (fNewDifficultyProtocol) {
-        targetTimespan = params.nPowTargetTimespanDigisheld;
+        targetTimespan = params.nPowTargetTimespanDigishield;
     }
 
     // Limit adjustment step


### PR DESCRIPTION
https://github.com/monacoinproject/monacoin/issues/52

A misspelled variable name `Digishield` has been fixed.

Digish`e`ld >> Digish`ie`ld