### PR TITLE
Update license year 2019

### DIFF
--- a/COPYING
+++ b/COPYING
@@ -1,13 +1,13 @@
 The MIT License (MIT)
 
-Copyright (c) 2009-2018 The Bitcoin Core developers
-Copyright (c) 2009-2018 Bitcoin Developers
-Copyright (c) 2011-2018 The Litecoin Core developers
-Copyright (C) 2011-2018 Dr. Kimoto Chan
-Copyright (C) 2011-2018 The DigiByte developers
-Copyright (C) 2014-2018 The Dash developers
-Copyright (C) 2014-2018 The Vertcoin Developers
-Copyright (C) 2013-2018 The Monacoin Core developers
+Copyright (c) 2009-2019 The Bitcoin Core developers
+Copyright (c) 2009-2019 Bitcoin Developers
+Copyright (c) 2011-2019 The Litecoin Core developers
+Copyright (C) 2011-2019 Dr. Kimoto Chan
+Copyright (C) 2011-2019 The DigiByte developers
+Copyright (C) 2014-2019 The Dash developers
+Copyright (C) 2014-2019 The Vertcoin Developers
+Copyright (C) 2013-2019 The Monacoin Core developers
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
### Fix license of use, 
update 2019; 
Format ISO 8869-1;
----------------------------------------------------------------------------------------------------------------------
in Memoriam Guto Schiavon 
![guto-schiavon_bitcoin](https://user-images.githubusercontent.com/7637553/50562143-a7506f80-0cf8-11e9-9e58-bed4565c4715.jpg)
R.I.P pioneer and friend. 

#ripGUTO