### PR TITLE
add dnsseed

### DIFF
--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -135,6 +135,7 @@ public:
 
         // Note that of those with the service bits flag, most only support a subset of possible options
         vSeeds.emplace_back("dnsseed.monacoin.org");
+        vSeeds.emplace_back("dnsseed.tamami-foundation.org");
 
         base58Prefixes[PUBKEY_ADDRESS] = std::vector<unsigned char>(1,50);  // M
         base58Prefixes[SCRIPT_ADDRESS] = std::vector<unsigned char>(1,5);


### PR DESCRIPTION
monad側で運用しているdnsseedを追加しました。

2014年にmonacoinが出来て以来、dnsseed.monacoin.orgが落ちていることは無かったかとは思います。
しかしながら約半年前に恐らく[この件](https://ascii.jp/elem/000/001/767/1767194/)でmaxconnectionsが最大値まで達して繋がらないpeerがdnsseedで返されていました。
またワタナベ氏に何かあった際にすぐに動けるようにしたいと言う意図もあります。

少なくともdnsseedを分散することでこの2つについて多少なりともリスクを緩和できるかと考えます。