### PR TITLE
Fix chainparams(m_is*)

### DIFF
--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -137,6 +137,7 @@ public:
         fDefaultConsistencyChecks = false;
         fRequireStandard = true;
         m_is_test_chain = false;
+        m_is_mockable_chain = false;
 
         checkpointData = {
             {
@@ -240,6 +241,7 @@ public:
         fDefaultConsistencyChecks = false;
         fRequireStandard = false;
         m_is_test_chain = true;
+        m_is_mockable_chain = false;
 
         checkpointData = {
             {
@@ -317,7 +319,9 @@ public:
         vSeeds.clear();      //!< Regtest mode doesn't have any DNS seeds.
 
         fDefaultConsistencyChecks = true;
-        fRequireStandard = false;
+        fRequireStandard = true;
+        m_is_test_chain = true;
+        m_is_mockable_chain = true;
 
         checkpointData = {
             {


### PR DESCRIPTION
`Error: acceptnonstdtxn is not currently supported for regtest chain`
The monacoind can't run regtest network.

