### PR TITLE
fix #121 by initializing memory and avoid breaking strict aliasing rules

### DIFF
--- a/src/crypto/Lyra2RE/bmw.c
+++ b/src/crypto/Lyra2RE/bmw.c
@@ -609,6 +609,7 @@ static const sph_u32 final_s[16] = {
 static void
 bmw32_init(sph_bmw_small_context *sc, const sph_u32 *iv)
 {
+	memset(sc, 0, sizeof(sph_bmw_small_context));
 	memcpy(sc->H, iv, sizeof sc->H);
 	sc->ptr = 0;
 #if SPH_64
@@ -759,6 +760,7 @@ static const sph_u64 final_b[16] = {
 static void
 bmw64_init(sph_bmw_big_context *sc, const sph_u64 *iv)
 {
+	memset(sc, 0, sizeof(sph_bmw_big_context));
 	memcpy(sc->H, iv, sizeof sc->H);
 	sc->ptr = 0;
 	sc->bit_count = 0;

--- a/src/crypto/Lyra2RE/sph_types.h
+++ b/src/crypto/Lyra2RE/sph_types.h
@@ -1427,9 +1427,13 @@ sph_dec32be(const void *src)
 #if defined SPH_UPTR
 #if SPH_UNALIGNED
 #if SPH_LITTLE_ENDIAN
-	return sph_bswap32(*(const sph_u32 *)src);
+	sph_u32 tmp;
+	memcpy(&tmp, src, sizeof(sph_u32));
+	return sph_bswap32(tmp);
 #else
-	return *(const sph_u32 *)src;
+	sph_u32 tmp;
+	memcpy(&tmp, src, sizeof(sph_u32));
+	return tmp;
 #endif
 #else
 	if (((SPH_UPTR)src & 3) == 0) {
@@ -1464,9 +1468,13 @@ static SPH_INLINE sph_u32
 sph_dec32be_aligned(const void *src)
 {
 #if SPH_LITTLE_ENDIAN
-	return sph_bswap32(*(const sph_u32 *)src);
+	sph_u32 tmp;
+	memcpy(&tmp, src, sizeof(sph_u32));
+	return sph_bswap32(tmp);
 #elif SPH_BIG_ENDIAN
-	return *(const sph_u32 *)src;
+	sph_u32 tmp;
+	memcpy(&tmp, src, sizeof(sph_u32));
+	return tmp;
 #else
 	return ((sph_u32)(((const unsigned char *)src)[0]) << 24)
 		| ((sph_u32)(((const unsigned char *)src)[1]) << 16)
@@ -1545,9 +1553,13 @@ sph_dec32le(const void *src)
 #if defined SPH_UPTR
 #if SPH_UNALIGNED
 #if SPH_BIG_ENDIAN
-	return sph_bswap32(*(const sph_u32 *)src);
+	sph_u32 tmp;
+	memcpy(&tmp, src, sizeof(sph_u32));
+	return sph_bswap32(tmp);
 #else
-	return *(const sph_u32 *)src;
+	sph_u32 tmp;
+	memcpy(&tmp, src, sizeof(sph_u32));
+	return tmp;
 #endif
 #else
 	if (((SPH_UPTR)src & 3) == 0) {
@@ -1615,7 +1627,9 @@ static SPH_INLINE sph_u32
 sph_dec32le_aligned(const void *src)
 {
 #if SPH_LITTLE_ENDIAN
-	return *(const sph_u32 *)src;
+	sph_u32 tmp;
+	memcpy(&tmp, src, sizeof(sph_u32));
+	return tmp;
 #elif SPH_BIG_ENDIAN
 #if SPH_SPARCV9_GCC && !SPH_NO_ASM
 	sph_u32 tmp;
@@ -1632,7 +1646,9 @@ sph_dec32le_aligned(const void *src)
 	return tmp;
  */
 #else
-	return sph_bswap32(*(const sph_u32 *)src);
+	sph_u32 tmp;
+	memcpy(&tmp, src, sizeof(sph_u32));
+	return sph_bswap32(tmp);
 #endif
 #else
 	return (sph_u32)(((const unsigned char *)src)[0])
@@ -1726,9 +1742,13 @@ sph_dec64be(const void *src)
 #if defined SPH_UPTR
 #if SPH_UNALIGNED
 #if SPH_LITTLE_ENDIAN
-	return sph_bswap64(*(const sph_u64 *)src);
+	sph_u64 tmp;
+	memcpy(&tmp, src, sizeof(sph_u64));
+	return sph_bswap64(tmp);
 #else
-	return *(const sph_u64 *)src;
+	sph_u64 tmp;
+	memcpy(&tmp, src, sizeof(sph_u64));
+	return tmp;
 #endif
 #else
 	if (((SPH_UPTR)src & 7) == 0) {
@@ -1771,9 +1791,13 @@ static SPH_INLINE sph_u64
 sph_dec64be_aligned(const void *src)
 {
 #if SPH_LITTLE_ENDIAN
-	return sph_bswap64(*(const sph_u64 *)src);
+	sph_u64 tmp;
+	memcpy(&tmp, src, sizeof(sph_u64));
+	return sph_bswap64(tmp);
 #elif SPH_BIG_ENDIAN
-	return *(const sph_u64 *)src;
+	sph_u64 tmp;
+	memcpy(&tmp, src, sizeof(sph_u64));
+	return tmp;
 #else
 	return ((sph_u64)(((const unsigned char *)src)[0]) << 56)
 		| ((sph_u64)(((const unsigned char *)src)[1]) << 48)
@@ -1868,9 +1892,13 @@ sph_dec64le(const void *src)
 #if defined SPH_UPTR
 #if SPH_UNALIGNED
 #if SPH_BIG_ENDIAN
-	return sph_bswap64(*(const sph_u64 *)src);
+	sph_u64 tmp;
+	memcpy(&tmp, src, sizeof(sph_u64));
+	return sph_bswap64(tmp);
 #else
-	return *(const sph_u64 *)src;
+	sph_u64 tmp;
+	memcpy(&tmp, src, sizeof(sph_u64));
+	return tmp;
 #endif
 #else
 	if (((SPH_UPTR)src & 7) == 0) {


### PR DESCRIPTION
This was quite a journey, but the conclusion is that the issue comes from the following (simplified) code:

```c
sph_dec32le_aligned(const void *src)
{
	return *(const sph_u32 *)src;
}
```

This converts parts of a `const unsigned char*` into a `sph_u32*` which gcc will consider to be pointing to different parts of memory (see: gcc strict aliasing rules).

Considering these are different parts of memory, gcc was feeling OK to move around those reads and writes to the input buffer, resulting in garbage results. When `compress_small` was called twice in the same function, gcc would apparently assume the reads were from the same piece of memory and group these, or something like that. Because `bmw32_close` calls `compress_small` multiple times in sequence, this would trigger the issue.

This was fixed by using a fixed size memcpy, which the compiler should optimize nicely while understanding it is not OK to reorder those reads.

Additionally, bmw32_init/bmw64_init didn't properly initialize memory, which also caused some issues, this is also fixed here.

Fixes https://github.com/monacoinproject/monacoin/issues/121